### PR TITLE
feat: Liquor expiredAt 컬럼 추가, CRU 로직 및 테스트에 반영

### DIFF
--- a/src/main/java/com/woowacamp/soolsool/core/liquor/domain/Liquor.java
+++ b/src/main/java/com/woowacamp/soolsool/core/liquor/domain/Liquor.java
@@ -20,6 +20,7 @@ import com.woowacamp.soolsool.global.common.BaseEntity;
 import com.woowacamp.soolsool.global.exception.GlobalErrorCode;
 import com.woowacamp.soolsool.global.exception.SoolSoolException;
 import java.math.BigInteger;
+import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Objects;
 import javax.persistence.Column;
@@ -93,6 +94,10 @@ public class Liquor extends BaseEntity {
     @Convert(converter = LiquorVolumeConverter.class)
     private LiquorVolume volume;
 
+    @Column(name = "expired_at", nullable = false)
+    @Getter
+    private LocalDateTime expiredAt;
+
     @Builder
     public Liquor(
         final LiquorBrew brew,
@@ -104,9 +109,14 @@ public class Liquor extends BaseEntity {
         final String imageUrl,
         final int stock,
         final Double alcohol,
-        final int volume
+        final int volume,
+        final LocalDateTime expiredAt
     ) {
-        this(null, brew, region, status, name, price, brand, imageUrl, stock, alcohol, volume);
+        this(null,
+            brew, region, status,
+            name, price, brand, imageUrl,
+            stock, alcohol, volume,
+            expiredAt);
     }
 
     public Liquor(
@@ -120,7 +130,8 @@ public class Liquor extends BaseEntity {
         final String imageUrl,
         final int stock,
         final Double alcohol,
-        final int volume
+        final int volume,
+        final LocalDateTime expiredAt
     ) {
         validateIsNotNullableCategory(brew, region, status);
 
@@ -135,6 +146,7 @@ public class Liquor extends BaseEntity {
         this.stock = new LiquorStock(stock);
         this.alcohol = new LiquorAlcohol(alcohol);
         this.volume = new LiquorVolume(volume);
+        this.expiredAt = expiredAt;
     }
 
     private void validateIsNotNullableCategory(final Object... objects) {
@@ -159,6 +171,7 @@ public class Liquor extends BaseEntity {
         this.stock = new LiquorStock(request.getStock());
         this.alcohol = new LiquorAlcohol(request.getAlcohol());
         this.volume = new LiquorVolume(request.getVolume());
+        this.expiredAt = request.getExpiredAt();
     }
 
     public boolean isStopped() {

--- a/src/main/java/com/woowacamp/soolsool/core/liquor/dto/LiquorDetailResponse.java
+++ b/src/main/java/com/woowacamp/soolsool/core/liquor/dto/LiquorDetailResponse.java
@@ -1,6 +1,7 @@
 package com.woowacamp.soolsool.core.liquor.dto;
 
 import com.woowacamp.soolsool.core.liquor.domain.Liquor;
+import java.time.LocalDateTime;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -16,6 +17,7 @@ public class LiquorDetailResponse {
     private final Integer stock;
     private final Double alcohol;
     private final Integer volume;
+    private final LocalDateTime expiredAt;
 
     public static LiquorDetailResponse from(final Liquor liquor) {
         return new LiquorDetailResponse(
@@ -26,7 +28,8 @@ public class LiquorDetailResponse {
             liquor.getImageUrl(),
             liquor.getStock(),
             liquor.getAlcohol(),
-            liquor.getVolume()
+            liquor.getVolume(),
+            liquor.getExpiredAt()
         );
     }
 }

--- a/src/main/java/com/woowacamp/soolsool/core/liquor/dto/LiquorModifyRequest.java
+++ b/src/main/java/com/woowacamp/soolsool/core/liquor/dto/LiquorModifyRequest.java
@@ -1,5 +1,6 @@
 package com.woowacamp.soolsool.core.liquor.dto;
 
+import java.time.LocalDateTime;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -17,4 +18,5 @@ public class LiquorModifyRequest {
     private final Integer stock;
     private final Double alcohol;
     private final Integer volume;
+    private final LocalDateTime expiredAt;
 }

--- a/src/main/java/com/woowacamp/soolsool/core/liquor/dto/LiquorSaveRequest.java
+++ b/src/main/java/com/woowacamp/soolsool/core/liquor/dto/LiquorSaveRequest.java
@@ -4,6 +4,7 @@ import com.woowacamp.soolsool.core.liquor.domain.Liquor;
 import com.woowacamp.soolsool.core.liquor.domain.LiquorBrew;
 import com.woowacamp.soolsool.core.liquor.domain.LiquorRegion;
 import com.woowacamp.soolsool.core.liquor.domain.LiquorStatus;
+import java.time.LocalDateTime;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -21,6 +22,7 @@ public class LiquorSaveRequest {
     private final Integer stock;
     private final Double alcohol;
     private final Integer volume;
+    private final LocalDateTime expiredAt;
 
     public Liquor toEntity(
         final LiquorBrew brew,
@@ -32,7 +34,8 @@ public class LiquorSaveRequest {
             brew, region,
             status, name,
             price, brand, imageUrl,
-            stock, alcohol, volume
+            stock, alcohol, volume,
+            expiredAt
         );
     }
 }

--- a/src/test/java/com/woowacamp/soolsool/acceptance/CartItemAcceptanceTest.java
+++ b/src/test/java/com/woowacamp/soolsool/acceptance/CartItemAcceptanceTest.java
@@ -16,6 +16,7 @@ import io.restassured.RestAssured;
 import io.restassured.common.mapper.TypeRef;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -35,7 +36,8 @@ class CartItemAcceptanceTest extends AcceptanceTest {
         LiquorSaveRequest liquorSaveRequest = new LiquorSaveRequest(
             "SOJU", "GYEONGSANGNAM_DO", "ON_SALE",
             "안동소주", "12000", "안동", "/soju.jpeg",
-            120, 31.3, 300
+            120, 31.3, 300,
+            LocalDateTime.now().plusYears(5L)
         );
         String location = RestAssured
             .given().log().all()
@@ -77,12 +79,15 @@ class CartItemAcceptanceTest extends AcceptanceTest {
         LiquorSaveRequest liquorSaveRequest = new LiquorSaveRequest(
             "SOJU", "GYEONGSANGNAM_DO", "ON_SALE",
             "안동소주", "12000", "안동", "/soju.jpeg",
-            120, 31.3, 300
+            120, 31.3, 300,
+            LocalDateTime.now().plusYears(5L)
         );
         LiquorSaveRequest liquorSaveRequest2 = new LiquorSaveRequest(
             "SOJU", "GYEONGGI_DO", "ON_SALE",
             "새로", "3000", "브랜드", "/soju-url",
-            100, 12.0, 300);
+            100, 12.0, 300,
+            LocalDateTime.now().plusYears(5L)
+        );
 
         Long liquorId = Long.parseLong(RestAssured
             .given().log().all()
@@ -148,7 +153,8 @@ class CartItemAcceptanceTest extends AcceptanceTest {
         LiquorSaveRequest liquorSaveRequest = new LiquorSaveRequest(
             "SOJU", "GYEONGSANGNAM_DO", "ON_SALE",
             "안동소주", "12000", "안동", "/soju.jpeg",
-            120, 31.3, 300
+            120, 31.3, 300,
+            LocalDateTime.now().plusYears(5L)
         );
         String location = RestAssured
             .given().log().all()
@@ -200,7 +206,8 @@ class CartItemAcceptanceTest extends AcceptanceTest {
         LiquorSaveRequest liquorSaveRequest = new LiquorSaveRequest(
             "SOJU", "GYEONGSANGNAM_DO", "ON_SALE",
             "안동소주", "12000", "안동", "/soju.jpeg",
-            120, 31.3, 300
+            120, 31.3, 300,
+            LocalDateTime.now().plusYears(5L)
         );
         String location = RestAssured
             .given().log().all()
@@ -262,12 +269,15 @@ class CartItemAcceptanceTest extends AcceptanceTest {
         LiquorSaveRequest liquorSaveRequest = new LiquorSaveRequest(
             "SOJU", "GYEONGSANGNAM_DO", "ON_SALE",
             "안동소주", "12000", "안동", "/soju.jpeg",
-            120, 31.3, 300
+            120, 31.3, 300,
+            LocalDateTime.now().plusYears(5L)
         );
         LiquorSaveRequest liquorSaveRequest2 = new LiquorSaveRequest(
             "SOJU", "GYEONGGI_DO", "ON_SALE",
             "새로", "3000", "브랜드", "/soju-url",
-            100, 12.0, 300);
+            100, 12.0, 300,
+            LocalDateTime.now().plusYears(5L)
+        );
 
         Long liquorId = Long.parseLong(RestAssured
             .given().log().all()

--- a/src/test/java/com/woowacamp/soolsool/acceptance/LiquorAcceptanceTest.java
+++ b/src/test/java/com/woowacamp/soolsool/acceptance/LiquorAcceptanceTest.java
@@ -20,6 +20,7 @@ import io.restassured.RestAssured;
 import io.restassured.common.mapper.TypeRef;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -58,15 +59,10 @@ class LiquorAcceptanceTest extends AcceptanceTest {
         // given
         String accessToken = findToken(EMAIL, PASSWORD);
         LiquorSaveRequest liquorSaveRequest = new LiquorSaveRequest(
-            "SOJU",
-            "GYEONGGI_DO",
-            "ON_SALE",
-            "새로",
-            "3000",
-            "브랜드",
-            "/url",
-            100, 12.0,
-            300);
+            "SOJU", "GYEONGGI_DO", "ON_SALE",
+            "새로", "3000", "브랜드", "/url",
+            100, 12.0, 300,
+            LocalDateTime.now().plusYears(5L));
 
         // when
         ExtractableResponse<Response> response = RestAssured
@@ -91,15 +87,10 @@ class LiquorAcceptanceTest extends AcceptanceTest {
         // given
         String accessToken = findToken(EMAIL, PASSWORD);
         LiquorSaveRequest saveLiquorRequest = new LiquorSaveRequest(
-            "SOJU",
-            "GYEONGGI_DO",
-            "ON_SALE",
-            "새로",
-            "3000",
-            "브랜드",
-            "/url",
-            100, 12.0,
-            300);
+            "SOJU", "GYEONGGI_DO", "ON_SALE",
+            "새로", "3000", "브랜드", "/url",
+            100, 12.0, 300,
+            LocalDateTime.now().plusYears(10L));
 
         ExtractableResponse<Response> saveLiquor = RestAssured
             .given().log().all()
@@ -113,16 +104,10 @@ class LiquorAcceptanceTest extends AcceptanceTest {
 
         Long liquorId = Long.parseLong(saveLiquor.header("Location").split("/")[2]);
         LiquorModifyRequest liquorModifyRequest = new LiquorModifyRequest(
-            "SOJU",
-            "GYEONGGI_DO",
-            "ON_SALE",
-            "안동소주",
-            "3000",
-            "브랜드",
-            "soolsool.png",
-            100,
-            12.0,
-            1
+            "SOJU", "GYEONGGI_DO", "ON_SALE",
+            "안동소주", "3000", "브랜드", "soolsool.png",
+            100, 12.0, 1,
+            LocalDateTime.now().plusYears(10L)
         );
 
         // when
@@ -148,15 +133,10 @@ class LiquorAcceptanceTest extends AcceptanceTest {
         // given
         String accessToken = findToken(EMAIL, PASSWORD);
         LiquorSaveRequest saveLiquorRequest = new LiquorSaveRequest(
-            "SOJU",
-            "GYEONGGI_DO",
-            "ON_SALE",
-            "새로",
-            "3000",
-            "브랜드",
-            "/url",
-            100, 12.0,
-            300);
+            "SOJU", "GYEONGGI_DO", "ON_SALE",
+            "새로", "3000", "브랜드", "/url",
+            100, 12.0, 300,
+            LocalDateTime.now().plusYears(5L));
 
         ExtractableResponse<Response> saveLiquor = RestAssured
             .given().log().all()
@@ -193,7 +173,9 @@ class LiquorAcceptanceTest extends AcceptanceTest {
         LiquorSaveRequest liquorSaveRequest = new LiquorSaveRequest(
             "SOJU", "GYEONGGI_DO", "ON_SALE",
             "새로", "3000", "브랜드", "/url",
-            100, 12.0, 300);
+            100, 12.0, 300,
+            LocalDateTime.now().plusYears(5L)
+        );
 
         String location = RestAssured
             .given().log().all()
@@ -239,11 +221,15 @@ class LiquorAcceptanceTest extends AcceptanceTest {
         LiquorSaveRequest saveSojuRequest = new LiquorSaveRequest(
             "SOJU", "GYEONGGI_DO", "ON_SALE",
             "새로", "3000", "브랜드", "/soju-url",
-            100, 12.0, 300);
+            100, 12.0, 300,
+            LocalDateTime.now().plusYears(5L)
+        );
         LiquorSaveRequest saveBeerRequest = new LiquorSaveRequest(
             "ETC", "GYEONGGI_DO", "ON_SALE",
             "하이트", "4000", "진로", "/beer-url",
-            200, 24.0, 600);
+            200, 24.0, 600,
+            LocalDateTime.now().plusYears(5L)
+        );
         String accessToken = findToken(EMAIL, PASSWORD);
 
         RestAssured
@@ -294,11 +280,15 @@ class LiquorAcceptanceTest extends AcceptanceTest {
         LiquorSaveRequest saveSojuRequest = new LiquorSaveRequest(
             "SOJU", "GYEONGGI_DO", "ON_SALE",
             "새로", "3000", "브랜드", "/soju-url",
-            100, 12.0, 300);
+            100, 12.0, 300,
+            LocalDateTime.now().plusYears(5L)
+        );
         LiquorSaveRequest saveBeerRequest = new LiquorSaveRequest(
             "ETC", "GYEONGGI_DO", "ON_SALE",
             "하이트", "4000", "진로", "/beer-url",
-            200, 24.0, 600);
+            200, 24.0, 600,
+            LocalDateTime.now().plusYears(5L)
+        );
         String accessToken = findToken(EMAIL, PASSWORD);
 
         RestAssured
@@ -350,11 +340,15 @@ class LiquorAcceptanceTest extends AcceptanceTest {
         LiquorSaveRequest saveSojuRequest = new LiquorSaveRequest(
             "SOJU", "GYEONGGI_DO", "ON_SALE",
             "새로", "3000", "브랜드", "/soju-url",
-            100, 12.0, 300);
+            100, 12.0, 300,
+            LocalDateTime.now().plusYears(5L)
+        );
         LiquorSaveRequest saveBeerRequest = new LiquorSaveRequest(
             "ETC", "CHUNGCHEONGBUK_DO", "ON_SALE",
             "하이트", "4000", "진로", "/beer-url",
-            200, 24.0, 600);
+            200, 24.0, 600,
+            LocalDateTime.now().plusYears(5L)
+        );
         String accessToken = findToken(EMAIL, PASSWORD);
 
         RestAssured
@@ -407,11 +401,15 @@ class LiquorAcceptanceTest extends AcceptanceTest {
         LiquorSaveRequest saveSojuRequest = new LiquorSaveRequest(
             "SOJU", "GYEONGGI_DO", "STOPPED",
             "새로", "3000", "브랜드", "/soju-url",
-            100, 12.0, 300);
+            100, 12.0, 300,
+            LocalDateTime.now().plusYears(5L)
+        );
         LiquorSaveRequest saveBeerRequest = new LiquorSaveRequest(
             "ETC", "CHUNGCHEONGBUK_DO", "ON_SALE",
             "하이트", "4000", "진로", "/beer-url",
-            200, 24.0, 600);
+            200, 24.0, 600,
+            LocalDateTime.now().plusYears(5L)
+        );
         String accessToken = findToken(EMAIL, PASSWORD);
 
         RestAssured
@@ -465,15 +463,19 @@ class LiquorAcceptanceTest extends AcceptanceTest {
         LiquorSaveRequest saveSojuRequest = new LiquorSaveRequest(
             "SOJU", "GYEONGGI_DO", "STOPPED",
             "새로", "3000", "브랜드", "/soju-url",
-            100, 12.0, 300);
+            100, 12.0, 300,
+            LocalDateTime.now().plusYears(5L));
         LiquorSaveRequest saveBeerRequest = new LiquorSaveRequest(
             "ETC", "CHUNGCHEONGBUK_DO", "ON_SALE",
             "하이트", "4000", "진로", "/beer-url",
-            200, 24.0, 600);
+            200, 24.0, 600,
+            LocalDateTime.now().plusYears(5L));
         LiquorSaveRequest saveBerryRequest = new LiquorSaveRequest(
             "BERRY", "JEOLLABUK_DO", "ON_SALE",
             "얼음딸기주", "4500", "우영미", "/strawberry-url",
-            20, 14.0, 400);
+            20, 14.0, 400,
+            LocalDateTime.now().plusYears(5L)
+        );
         String accessToken = findToken(EMAIL, PASSWORD);
 
         RestAssured

--- a/src/test/java/com/woowacamp/soolsool/core/liquor/service/LiquorServiceTest.java
+++ b/src/test/java/com/woowacamp/soolsool/core/liquor/service/LiquorServiceTest.java
@@ -9,6 +9,7 @@ import com.woowacamp.soolsool.core.liquor.dto.LiquorModifyRequest;
 import com.woowacamp.soolsool.core.liquor.dto.LiquorSaveRequest;
 import com.woowacamp.soolsool.core.liquor.repository.LiquorRepository;
 import com.woowacamp.soolsool.global.exception.SoolSoolException;
+import java.time.LocalDateTime;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -31,15 +32,10 @@ class LiquorServiceTest {
     void saveLiquorTest() {
         // given
         LiquorSaveRequest saveLiquorRequest = new LiquorSaveRequest(
-            "SOJU",
-            "GYEONGGI_DO",
-            "ON_SALE",
-            "새로",
-            "3000",
-            "브랜드",
-            "/url",
-            100, 12.0,
-            300);
+            "SOJU", "GYEONGGI_DO", "ON_SALE",
+            "새로", "3000", "브랜드", "/url",
+            100, 12.0, 300,
+            LocalDateTime.now().plusYears(5L));
         // when & then
         assertThatCode(() -> liquorService.saveLiquor(saveLiquorRequest))
             .doesNotThrowAnyException();
@@ -50,27 +46,16 @@ class LiquorServiceTest {
     void modifyLiquorTestWithSuccess() {
         // given
         LiquorSaveRequest saveLiquorRequest = new LiquorSaveRequest(
-            "SOJU",
-            "GYEONGGI_DO",
-            "ON_SALE",
-            "새로",
-            "3000",
-            "브랜드",
-            "/url",
-            100, 12.0,
-            300);
+            "SOJU", "GYEONGGI_DO", "ON_SALE",
+            "새로", "3000", "브랜드", "/url",
+            100, 12.0, 300,
+            LocalDateTime.now().plusYears(5L));
         Long saveLiquorId = liquorService.saveLiquor(saveLiquorRequest);
         LiquorModifyRequest liquorModifyRequest = new LiquorModifyRequest(
-            "SOJU",
-            "GYEONGGI_DO",
-            "ON_SALE",
-            "안동소주",
-            "3000",
-            "브랜드",
-            "soolsool.png",
-            100,
-            12.0,
-            1
+            "SOJU", "GYEONGGI_DO", "ON_SALE",
+            "안동소주", "3000", "브랜드", "soolsool.png",
+            100, 12.0, 1,
+            LocalDateTime.now().plusYears(10L)
         );
         // when
         liquorService.modifyLiquor(saveLiquorId, liquorModifyRequest);

--- a/src/test/java/com/woowacamp/soolsool/integration/repository/CartItemRepositoryTest.java
+++ b/src/test/java/com/woowacamp/soolsool/integration/repository/CartItemRepositoryTest.java
@@ -15,6 +15,7 @@ import com.woowacamp.soolsool.core.liquor.repository.LiquorStatusRepository;
 import com.woowacamp.soolsool.core.member.domain.Member;
 import com.woowacamp.soolsool.core.member.repository.MemberRepository;
 import com.woowacamp.soolsool.core.member.repository.MemberRoleRepository;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -31,9 +32,6 @@ class CartItemRepositoryTest {
 
     @Autowired
     private MemberRepository memberRepository;
-
-    @Autowired
-    private MemberRoleRepository memberRoleRepository;
 
     @Autowired
     private LiquorBrewRepository liquorBrewRepository;
@@ -114,6 +112,7 @@ class CartItemRepositoryTest {
             .stock(120)
             .alcohol(21.8)
             .volume(400)
+            .expiredAt(LocalDateTime.now().plusYears(5L))
             .build();
         liquor = liquorRepository.save(liquor);
         Liquor liquor2 = Liquor.builder()
@@ -127,6 +126,7 @@ class CartItemRepositoryTest {
             .stock(120)
             .alcohol(21.8)
             .volume(400)
+            .expiredAt(LocalDateTime.now().plusYears(5L))
             .build();
         liquor2 = liquorRepository.save(liquor2);
 
@@ -151,7 +151,6 @@ class CartItemRepositoryTest {
         assertThat(cartItemList).hasSize(2);
     }
 
-
     @Test
     @DisplayName("유저 아이디에 따른 장바구니 모든 아이템 삭제")
     void deleteAllTest() {
@@ -173,6 +172,7 @@ class CartItemRepositoryTest {
             .stock(120)
             .alcohol(21.8)
             .volume(400)
+            .expiredAt(LocalDateTime.now().plusYears(5L))
             .build();
         liquor = liquorRepository.save(liquor);
         Liquor liquor2 = Liquor.builder()
@@ -186,6 +186,7 @@ class CartItemRepositoryTest {
             .stock(120)
             .alcohol(21.8)
             .volume(400)
+            .expiredAt(LocalDateTime.now().plusYears(5L))
             .build();
         liquor2 = liquorRepository.save(liquor2);
 

--- a/src/test/java/com/woowacamp/soolsool/integration/service/CartServiceTest.java
+++ b/src/test/java/com/woowacamp/soolsool/integration/service/CartServiceTest.java
@@ -12,6 +12,7 @@ import com.woowacamp.soolsool.core.cart.service.CartService;
 import com.woowacamp.soolsool.core.liquor.dto.LiquorSaveRequest;
 import com.woowacamp.soolsool.core.liquor.service.LiquorService;
 import com.woowacamp.soolsool.global.exception.SoolSoolException;
+import java.time.LocalDateTime;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -50,15 +51,10 @@ class CartServiceTest {
         // given
         Long memberId = 1L;
         LiquorSaveRequest liquorSaveRequest = new LiquorSaveRequest(
-            "SOJU",
-            "GYEONGGI_DO",
-            "ON_SALE",
-            "새로",
-            "3000",
-            "브랜드",
-            "/url",
-            100, 12.0,
-            300);
+            "SOJU", "GYEONGGI_DO", "ON_SALE",
+            "새로", "3000", "브랜드", "/url",
+            100, 12.0, 300,
+            LocalDateTime.now().plusYears(10L));
         Long saveLiquorId = liquorService.saveLiquor(liquorSaveRequest);
 
         CartItemSaveRequest request = new CartItemSaveRequest(saveLiquorId, 1);
@@ -82,15 +78,10 @@ class CartServiceTest {
         Long memberId = 1L;
         Long anotherMemberId = 2L;
         LiquorSaveRequest liquorSaveRequest = new LiquorSaveRequest(
-            "SOJU",
-            "GYEONGGI_DO",
-            "ON_SALE",
-            "새로",
-            "3000",
-            "브랜드",
-            "/url",
-            100, 12.0,
-            300);
+            "SOJU", "GYEONGGI_DO", "ON_SALE",
+            "새로", "3000", "브랜드", "/url",
+            100, 12.0, 300,
+            LocalDateTime.now().plusYears(10L));
         Long saveLiquorId = liquorService.saveLiquor(liquorSaveRequest);
         CartItemSaveRequest request = new CartItemSaveRequest(saveLiquorId, 1);
         Long cartItemId = cartService.addCartItem(memberId, request);

--- a/src/test/java/com/woowacamp/soolsool/integration/service/LiquorServiceTest.java
+++ b/src/test/java/com/woowacamp/soolsool/integration/service/LiquorServiceTest.java
@@ -14,6 +14,7 @@ import com.woowacamp.soolsool.core.liquor.repository.LiquorRepository;
 import com.woowacamp.soolsool.core.liquor.repository.LiquorStatusRepository;
 import com.woowacamp.soolsool.core.liquor.service.LiquorService;
 import com.woowacamp.soolsool.global.exception.SoolSoolException;
+import java.time.LocalDateTime;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -46,15 +47,10 @@ class LiquorServiceTest {
     void saveLiquorTest() {
         // given
         LiquorSaveRequest liquorSaveRequest = new LiquorSaveRequest(
-            "SOJU",
-            "GYEONGGI_DO",
-            "ON_SALE",
-            "새로",
-            "3000",
-            "브랜드",
-            "/url",
-            100, 12.0,
-            300);
+            "SOJU", "GYEONGGI_DO", "ON_SALE",
+            "새로", "3000", "브랜드", "/url",
+            100, 12.0, 300,
+            LocalDateTime.now().plusYears(5L));
 
         // when & then
         assertThatCode(() -> liquorService.saveLiquor(liquorSaveRequest))
@@ -66,26 +62,16 @@ class LiquorServiceTest {
     void modifyLiquorTest() {
         // given
         LiquorSaveRequest liquorSaveRequest = new LiquorSaveRequest(
-            "SOJU",
-            "GYEONGGI_DO",
-            "ON_SALE",
-            "새로",
-            "3000",
-            "브랜드",
-            "/url",
-            100, 12.0,
-            300);
+            "SOJU", "GYEONGGI_DO", "ON_SALE",
+            "새로", "3000", "브랜드", "/url",
+            100, 12.0, 300,
+            LocalDateTime.now().plusYears(5L));
         Long saveLiquorId = liquorService.saveLiquor(liquorSaveRequest);
         LiquorModifyRequest liquorModifyRequest = new LiquorModifyRequest(
-            "BERRY",
-            "GYEONGGI_DO",
-            "ON_SALE",
-            "새로2",
-            "3000",
-            "브랜드",
-            "/url",
-            100, 12.0,
-            300
+            "BERRY", "GYEONGGI_DO", "ON_SALE",
+            "새로2", "3000", "브랜드", "/url",
+            100, 12.0, 300,
+            LocalDateTime.now().plusYears(10L)
         );
         // when
         liquorService.modifyLiquor(saveLiquorId, liquorModifyRequest);
@@ -105,15 +91,10 @@ class LiquorServiceTest {
         // given
         long LIQUOR_ID = 2L;
         LiquorModifyRequest liquorModifyRequest = new LiquorModifyRequest(
-            "BERRY",
-            "GYEONGGI_DO",
-            "ON_SALE",
-            "새로2",
-            "3000",
-            "브랜드",
-            "/url",
-            100, 12.0,
-            300
+            "BERRY", "GYEONGGI_DO", "ON_SALE",
+            "새로2", "3000", "브랜드", "/url",
+            100, 12.0, 300,
+            LocalDateTime.now().plusYears(10L)
         );
         // when & then
         assertThatCode(() -> liquorService.modifyLiquor(LIQUOR_ID, liquorModifyRequest))
@@ -127,15 +108,10 @@ class LiquorServiceTest {
     void deleteLiquorTest() {
         // given
         LiquorSaveRequest liquorSaveRequest = new LiquorSaveRequest(
-            "SOJU",
-            "GYEONGGI_DO",
-            "ON_SALE",
-            "새로",
-            "3000",
-            "브랜드",
-            "/url",
-            100, 12.0,
-            300);
+            "SOJU", "GYEONGGI_DO", "ON_SALE",
+            "새로", "3000", "브랜드", "/url",
+            100, 12.0, 300,
+            LocalDateTime.now().plusYears(10L));
         Long saveLiquorId = liquorService.saveLiquor(liquorSaveRequest);
 
         // when

--- a/src/test/java/com/woowacamp/soolsool/unit/domain/CartTest.java
+++ b/src/test/java/com/woowacamp/soolsool/unit/domain/CartTest.java
@@ -13,6 +13,7 @@ import com.woowacamp.soolsool.core.liquor.domain.vo.LiquorBrewType;
 import com.woowacamp.soolsool.core.liquor.domain.vo.LiquorRegionType;
 import com.woowacamp.soolsool.core.liquor.domain.vo.LiquorStatusType;
 import com.woowacamp.soolsool.global.exception.SoolSoolException;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -36,12 +37,14 @@ class CartTest {
         soju = new Liquor(
             1L, sojuBrew, gyeongSangNamDoRegion, onSaleStatus,
             "안동 소주", "12000", "안동", "/soju.jpg",
-            120, 21.7, 400
+            120, 21.7, 400,
+            LocalDateTime.now()
         );
         beer = new Liquor(
             2L, etcBrew, gyeongSangNamDoRegion, stoppedStatus,
             "맥주", "5000", "OB", "/beer.jpg",
-            20, 5.7, 500
+            20, 5.7, 500,
+            LocalDateTime.now()
         );
     }
 


### PR DESCRIPTION
## ♻️ 변경 사항

```
ex)
### docs: PULL_REQUEST_TEMPLATE.md 작성 ... [a6684f7](https://github.com/five-uys/test/commit/7625214be558f7496cca1dec633f02942799dff1)

* PR 생성 시 자동으로 적용될 템플릿
* ...
```
* Liquor 엔티티에 expiredAt (유통기한) 컬럼 추가
* CRU 로직에 반영
* 테스트에 반영

<br>

## 📌 참고 사항

```
ex)
* 결제 부분 로직이 복잡한데, ~~~ 이유로 ~~~ 를 구현하기 위해 불가피했읍니다.
* ...
```


<br>

## 🎸 기타

```
ex) 닫을 이슈가 있다면,
closes #이슈번호
```
closes #101 
