### PR TITLE
feat: KakaoPayReceipt 엔티티 구현

### DIFF
--- a/src/main/java/com/woowacamp/soolsool/core/payment/domain/KakaoPayReceipt.java
+++ b/src/main/java/com/woowacamp/soolsool/core/payment/domain/KakaoPayReceipt.java
@@ -1,0 +1,29 @@
+package com.woowacamp.soolsool.core.payment.domain;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "kakao_pay_receipts")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class KakaoPayReceipt {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "receipt_id", nullable = false)
+    private Long receiptId;
+
+    @Column(name = "tid", nullable = false)
+    private String tid;
+}


### PR DESCRIPTION
## ♻️ 변경 사항
카카오 결제정보인 kakayPayReceipt 엔티티 생성 


<br>

## 📌 참고 사항



<br>

## 🎸 기타

```
ex) 닫을 이슈가 있다면,
closes #이슈번호
```
closes #91 

