### PR TITLE
feat: 술 상세정보 조회 시 해당 술과 함께 많이 구매된 술도 조회하여 반환

### DIFF
--- a/src/main/java/com/woowacamp/soolsool/core/liquor/dto/LiquorDetailResponse.java
+++ b/src/main/java/com/woowacamp/soolsool/core/liquor/dto/LiquorDetailResponse.java
@@ -1,6 +1,8 @@
 package com.woowacamp.soolsool.core.liquor.dto;
 
 import com.woowacamp.soolsool.core.liquor.domain.Liquor;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -16,8 +18,13 @@ public class LiquorDetailResponse {
     private final Integer stock;
     private final Double alcohol;
     private final Integer volume;
+    private final List<LiquorElementResponse> relatedLiquors;
 
-    public static LiquorDetailResponse from(final Liquor liquor) {
+    public static LiquorDetailResponse of(final Liquor liquor, final List<Liquor> relatedLiquors) {
+        final List<LiquorElementResponse> relatedLiquorResponses = relatedLiquors.stream()
+            .map(LiquorElementResponse::from)
+            .collect(Collectors.toList());
+
         return new LiquorDetailResponse(
             liquor.getId(),
             liquor.getName(),
@@ -26,7 +33,8 @@ public class LiquorDetailResponse {
             liquor.getImageUrl(),
             liquor.getTotalStock(),
             liquor.getAlcohol(),
-            liquor.getVolume()
+            liquor.getVolume(),
+            relatedLiquorResponses
         );
     }
 }

--- a/src/main/java/com/woowacamp/soolsool/core/liquor/repository/LiquorRepository.java
+++ b/src/main/java/com/woowacamp/soolsool/core/liquor/repository/LiquorRepository.java
@@ -18,6 +18,7 @@ public interface LiquorRepository extends JpaRepository<Liquor, Long> {
         + " where ri.receipt.id in (select sub_ri.receipt.id"
         + "                         from ReceiptItem sub_ri"
         + "                         where sub_ri.liquorId = :liquorId)"
+        + "       and o.status.id = 1"
         + "       and ri.liquorId != :liquorId"
         + " group by ri.liquorId"
         + " order by count(ri.liquorId) desc")

--- a/src/main/java/com/woowacamp/soolsool/core/liquor/repository/LiquorRepository.java
+++ b/src/main/java/com/woowacamp/soolsool/core/liquor/repository/LiquorRepository.java
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Repository;
 public interface LiquorRepository extends JpaRepository<Liquor, Long> {
 
     @Query("select ri.liquorId"
-        + " from ReceiptItem ri"
+        + " from Order o inner join ReceiptItem ri on o.receipt = ri.receipt"
         + " where ri.receipt.id in (select sub_ri.receipt.id"
         + "                         from ReceiptItem sub_ri"
         + "                         where sub_ri.liquorId = :liquorId)"

--- a/src/main/java/com/woowacamp/soolsool/core/liquor/repository/LiquorRepository.java
+++ b/src/main/java/com/woowacamp/soolsool/core/liquor/repository/LiquorRepository.java
@@ -1,23 +1,32 @@
 package com.woowacamp.soolsool.core.liquor.repository;
 
-import static javax.persistence.LockModeType.PESSIMISTIC_WRITE;
-
 import com.woowacamp.soolsool.core.liquor.domain.Liquor;
-import java.util.Optional;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface LiquorRepository extends JpaRepository<Liquor, Long> {
 
-    @Lock(value = PESSIMISTIC_WRITE)
-    @Query("select l from Liquor l where l.id = :liquorId")
-    Optional<Liquor> findLiquorByIdWithLock(final Long liquorId);
+    @Query("select ri.liquorId"
+        + " from ReceiptItem ri"
+        + " where ri.receipt.id in (select sub_ri.receipt.id"
+        + "                         from ReceiptItem sub_ri"
+        + "                         where sub_ri.liquorId = :liquorId)"
+        + "       and ri.liquorId != :liquorId"
+        + " group by ri.liquorId"
+        + " order by count(ri.liquorId) desc")
+    List<Long> findLiquorsPurchasedTogether(
+        @Param("liquorId") final Long liquorId,
+        final Pageable pageableForLimit
+    );
+
+    List<Liquor> findAllByIdIn(final List<Long> liquorIds);
 
     Page<Liquor> findAll(final Specification<Liquor> conditions, final Pageable pageable);
 }

--- a/src/main/java/com/woowacamp/soolsool/core/liquor/service/LiquorService.java
+++ b/src/main/java/com/woowacamp/soolsool/core/liquor/service/LiquorService.java
@@ -21,7 +21,6 @@ import com.woowacamp.soolsool.core.liquor.repository.LiquorBrewRepository;
 import com.woowacamp.soolsool.core.liquor.repository.LiquorRegionRepository;
 import com.woowacamp.soolsool.core.liquor.repository.LiquorRepository;
 import com.woowacamp.soolsool.core.liquor.repository.LiquorStatusRepository;
-import com.woowacamp.soolsool.core.receipt.repository.ReceiptRepository;
 import com.woowacamp.soolsool.global.exception.SoolSoolException;
 import java.util.ArrayList;
 import java.util.List;
@@ -47,7 +46,6 @@ public class LiquorService {
     private final LiquorStatusRepository liquorStatusRepository;
     private final LiquorRegionRepository liquorRegionRepository;
     private final LiquorBrewRepository liquorBrewRepository;
-    private final ReceiptRepository receiptRepository;
 
     @Transactional
     public Long saveLiquor(final LiquorSaveRequest request) {

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -11,7 +11,7 @@ spring:
     database: mysql
     show-sql: true
     hibernate:
-      ddl-auto: create
+      ddl-auto: none
     properties:
       hibernate:
         show_sql: true


### PR DESCRIPTION
## ♻️ 변경 사항

### 술 상세정보 조회 시 해당 술과 함께 많이 구매된 술도 조회

* 쿼리 (서브 쿼리 사용하여 하나의 쿼리로 축약)
    1. `liquorId` 술을 구매한 주문서 Id 조회
    2. 1번에 해당하는 주문서 중 `결제완료`된 주문만 필터링
    3. 2번 결과에서 group by, order by를 사용하여 함께 가장 많이 구매된 술 id 조회

<br>

## 📌 참고 사항

예시 (API 문서 수정 완료)
```json
{
    "status": 200,
    "code": "L102",
    "message": "술 상세 정보가 정상적으로 검색되었습니다.",
    "data": {
        "id": 3,
        "name": "새로",
        "price": "3000",
        "brand": "롯데",
        "imageUrl": "/soju-url",
        "stock": 99,
        "alcohol": 12.0,
        "volume": 300,
        "relatedLiquors": [
            {
                "id": 5,
                "name": "얼음딸기주",
                "price": "4500",
                "imageUrl": "/strawberry-url",
                "stock": 99
            }
        ]
    }
}
```

<br>

## 🎸 기타

closes #136 