### PR TITLE
refactor: 함께 많이 구매된 술 조회 시 liquorId 대신 Liquor 객체를 바로 조회

### DIFF
--- a/src/main/java/com/woowacamp/soolsool/core/liquor/service/LiquorService.java
+++ b/src/main/java/com/woowacamp/soolsool/core/liquor/service/LiquorService.java
@@ -63,9 +63,8 @@ public class LiquorService {
         final Liquor liquor = liquorRepository.findById(liquorId)
             .orElseThrow(() -> new SoolSoolException(NOT_LIQUOR_FOUND));
 
-        final List<Liquor> relatedLiquors = liquorRepository.findAllByIdIn(
-            liquorRepository.findLiquorsPurchasedTogether(liquorId, TOP_RANK_PAGEABLE)
-        );
+        final List<Liquor> relatedLiquors =
+            liquorRepository.findLiquorsPurchasedTogether(liquorId, TOP_RANK_PAGEABLE);
 
         return LiquorDetailResponse.of(liquor, relatedLiquors);
     }


### PR DESCRIPTION
## ♻️ 변경 사항

```
ex)
### docs: PULL_REQUEST_TEMPLATE.md 작성 ... [a6684f7](https://github.com/five-uys/test/commit/7625214be558f7496cca1dec633f02942799dff1)

* PR 생성 시 자동으로 적용될 템플릿
* ...
```
함께 많이 구매된 술 조회 시 liquorId 대신 Liquor 객체를 바로 조회

<br>

## 📌 참고 사항

```
ex)
* 결제 부분 로직이 복잡한데, ~~~ 이유로 ~~~ 를 구현하기 위해 불가피했읍니다.
* ...
```


<br>

## 🎸 기타

```
ex) 닫을 이슈가 있다면,
closes #이슈번호
```

