### PR TITLE
feat: 결제 실패 및 취소 시 주문 취소 기능 추가

### DIFF
--- a/src/main/java/com/woowacamp/soolsool/core/payment/controller/PayController.java
+++ b/src/main/java/com/woowacamp/soolsool/core/payment/controller/PayController.java
@@ -73,7 +73,7 @@ public class PayController {
         log.info("{} {} | memberId : {}",
             httpServletRequest.getMethod(), httpServletRequest.getServletPath(), memberId);
 
-        payService.modifyReceiptStatusToCancel(memberId, receiptId);
+        payService.cancelReceipt(memberId, receiptId);
 
         return ResponseEntity.ok(ApiResponse.from(PAY_READY_CANCEL));
     }
@@ -88,7 +88,7 @@ public class PayController {
         log.info("{} {} | memberId : {}",
             httpServletRequest.getMethod(), httpServletRequest.getServletPath(), memberId);
 
-        payService.modifyReceiptStatusToCancel(memberId, receiptId);
+        payService.cancelReceipt(memberId, receiptId);
 
         return ResponseEntity.ok(ApiResponse.from(PAY_READY_FAIL));
     }

--- a/src/main/java/com/woowacamp/soolsool/core/payment/controller/PayController.java
+++ b/src/main/java/com/woowacamp/soolsool/core/payment/controller/PayController.java
@@ -67,24 +67,29 @@ public class PayController {
     @GetMapping("/cancel/{receiptId}")
     public ResponseEntity<ApiResponse<Long>> kakaoPayCancel(
         final HttpServletRequest httpServletRequest,
-        @LoginUser final Long memberId
+        @LoginUser final Long memberId,
+        @PathVariable final Long receiptId
     ) {
         log.info("{} {} | memberId : {}",
             httpServletRequest.getMethod(), httpServletRequest.getServletPath(), memberId);
 
-        return ResponseEntity.ok(ApiResponse.of(PAY_READY_CANCEL, null));
+        payService.modifyReceiptStatusToCancel(memberId, receiptId);
+
+        return ResponseEntity.ok(ApiResponse.from(PAY_READY_CANCEL));
     }
 
     @NoAuth
     @GetMapping("/fail/{receiptId}")
     public ResponseEntity<ApiResponse<Long>> kakaoPayFail(
         final HttpServletRequest httpServletRequest,
-        @LoginUser final Long memberId
+        @LoginUser final Long memberId,
+        @PathVariable final Long receiptId
     ) {
         log.info("{} {} | memberId : {}",
             httpServletRequest.getMethod(), httpServletRequest.getServletPath(), memberId);
 
-        return ResponseEntity.ok(ApiResponse.of(PAY_READY_FAIL, null));
-    }
+        payService.modifyReceiptStatusToCancel(memberId, receiptId);
 
+        return ResponseEntity.ok(ApiResponse.from(PAY_READY_FAIL));
+    }
 }

--- a/src/main/java/com/woowacamp/soolsool/core/payment/service/PayService.java
+++ b/src/main/java/com/woowacamp/soolsool/core/payment/service/PayService.java
@@ -60,7 +60,7 @@ public class PayService {
     }
 
     @Transactional
-    public void modifyReceiptStatusToCancel(final Long memberId, final Long receiptId) {
+    public void cancelReceipt(final Long memberId, final Long receiptId) {
         receiptService.modifyReceiptStatus(memberId, receiptId, ReceiptStatusType.CANCELED);
     }
 }

--- a/src/main/java/com/woowacamp/soolsool/core/payment/service/PayService.java
+++ b/src/main/java/com/woowacamp/soolsool/core/payment/service/PayService.java
@@ -11,6 +11,7 @@ import com.woowacamp.soolsool.core.payment.dto.response.PayReadyResponse;
 import com.woowacamp.soolsool.core.payment.infra.PayClient;
 import com.woowacamp.soolsool.core.receipt.domain.Receipt;
 import com.woowacamp.soolsool.core.receipt.domain.ReceiptItem;
+import com.woowacamp.soolsool.core.receipt.domain.vo.ReceiptStatusType;
 import com.woowacamp.soolsool.core.receipt.service.ReceiptService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -56,5 +57,10 @@ public class PayService {
         orderService.addPaymentInfo(payClient.payApprove(receipt, pgToken).toEntity(order.getId()));
 
         return order;
+    }
+
+    @Transactional
+    public void modifyReceiptStatusToCancel(final Long memberId, final Long receiptId) {
+        receiptService.modifyReceiptStatus(memberId, receiptId, ReceiptStatusType.CANCELED);
     }
 }

--- a/src/main/java/com/woowacamp/soolsool/core/receipt/controller/ReceiptController.java
+++ b/src/main/java/com/woowacamp/soolsool/core/receipt/controller/ReceiptController.java
@@ -3,7 +3,7 @@ package com.woowacamp.soolsool.core.receipt.controller;
 import static com.woowacamp.soolsool.core.receipt.code.ReceiptResultCode.RECEIPT_ADD_SUCCESS;
 import static com.woowacamp.soolsool.core.receipt.code.ReceiptResultCode.RECEIPT_FOUND;
 
-import com.woowacamp.soolsool.core.receipt.dto.response.ReceiptResponse;
+import com.woowacamp.soolsool.core.receipt.dto.response.ReceiptDetailResponse;
 import com.woowacamp.soolsool.core.receipt.service.ReceiptService;
 import com.woowacamp.soolsool.global.auth.dto.LoginUser;
 import com.woowacamp.soolsool.global.common.ApiResponse;
@@ -41,7 +41,7 @@ public class ReceiptController {
     }
 
     @GetMapping("/{receiptId}")
-    public ResponseEntity<ApiResponse<ReceiptResponse>> receiptDetails(
+    public ResponseEntity<ApiResponse<ReceiptDetailResponse>> receiptDetails(
         final HttpServletRequest httpServletRequest,
         @LoginUser final Long memberId,
         @PathVariable final Long receiptId
@@ -49,7 +49,7 @@ public class ReceiptController {
         log.info("{} {} | memberId : {}",
             httpServletRequest.getMethod(), httpServletRequest.getServletPath(), memberId);
 
-        final ReceiptResponse receipt = receiptService.findReceipt(memberId, receiptId);
+        final ReceiptDetailResponse receipt = receiptService.findReceipt(memberId, receiptId);
 
         return ResponseEntity.ok(ApiResponse.of(RECEIPT_FOUND, receipt));
     }

--- a/src/main/java/com/woowacamp/soolsool/core/receipt/domain/Receipt.java
+++ b/src/main/java/com/woowacamp/soolsool/core/receipt/domain/Receipt.java
@@ -4,7 +4,6 @@ import com.woowacamp.soolsool.core.receipt.domain.converter.ReceiptItemPriceConv
 import com.woowacamp.soolsool.core.receipt.domain.converter.ReceiptItemQuantityConverter;
 import com.woowacamp.soolsool.core.receipt.domain.vo.ReceiptItemPrice;
 import com.woowacamp.soolsool.core.receipt.domain.vo.ReceiptItemQuantity;
-import com.woowacamp.soolsool.core.receipt.domain.vo.ReceiptStatusType;
 import com.woowacamp.soolsool.global.common.BaseEntity;
 import java.math.BigInteger;
 import java.time.LocalDateTime;
@@ -93,8 +92,8 @@ public class Receipt extends BaseEntity {
         receiptItems.forEach(receiptItem -> receiptItem.setReceipt(this));
     }
 
-    public void updateStatus(final ReceiptStatusType type) {
-        this.receiptStatus.updateStatus(type);
+    public void updateStatus(final ReceiptStatus receiptStatus) {
+        this.receiptStatus = receiptStatus;
     }
 
     public BigInteger getOriginalTotalPrice() {

--- a/src/main/java/com/woowacamp/soolsool/core/receipt/dto/response/ReceiptDetailResponse.java
+++ b/src/main/java/com/woowacamp/soolsool/core/receipt/dto/response/ReceiptDetailResponse.java
@@ -8,7 +8,7 @@ import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public class ReceiptResponse {
+public class ReceiptDetailResponse {
 
     private final Long id;
     private final Long memberId;
@@ -19,14 +19,14 @@ public class ReceiptResponse {
     private final int totalQuantity;
     private final List<ReceiptItemResponse> receiptItemResponse;
 
-    public static ReceiptResponse from(final Receipt receipt) {
+    public static ReceiptDetailResponse from(final Receipt receipt) {
         final List<ReceiptItemResponse> items = receipt
             .getReceiptItems()
             .stream()
             .map(ReceiptItemResponse::from)
             .collect(Collectors.toList());
 
-        return new ReceiptResponse(
+        return new ReceiptDetailResponse(
             receipt.getId(),
             receipt.getMemberId(),
             receipt.getReceiptStatus(),

--- a/src/main/java/com/woowacamp/soolsool/core/receipt/service/ReceiptService.java
+++ b/src/main/java/com/woowacamp/soolsool/core/receipt/service/ReceiptService.java
@@ -13,9 +13,9 @@ import com.woowacamp.soolsool.core.receipt.code.ReceiptErrorCode;
 import com.woowacamp.soolsool.core.receipt.domain.Receipt;
 import com.woowacamp.soolsool.core.receipt.domain.ReceiptStatus;
 import com.woowacamp.soolsool.core.receipt.domain.vo.ReceiptStatusType;
-import com.woowacamp.soolsool.core.receipt.dto.response.ReceiptResponse;
+import com.woowacamp.soolsool.core.receipt.dto.response.ReceiptDetailResponse;
 import com.woowacamp.soolsool.core.receipt.repository.ReceiptRepository;
-import com.woowacamp.soolsool.core.receipt.repository.ReceiptStatusRepository;
+import com.woowacamp.soolsool.core.receipt.repository.ReceiptStatusCache;
 import com.woowacamp.soolsool.global.exception.SoolSoolException;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
@@ -28,7 +28,7 @@ public class ReceiptService {
 
     private final ReceiptMapper receiptMapper;
     private final ReceiptRepository receiptRepository;
-    private final ReceiptStatusRepository receiptStatusRepository;
+    private final ReceiptStatusCache receiptStatusCache;
     private final CartItemRepository cartItemRepository;
     private final MemberRepository memberRepository;
 
@@ -44,7 +44,7 @@ public class ReceiptService {
     }
 
     @Transactional(readOnly = true)
-    public ReceiptResponse findReceipt(final Long memberId, final Long receiptId) {
+    public ReceiptDetailResponse findReceipt(final Long memberId, final Long receiptId) {
         final Receipt receipt = receiptRepository.findById(receiptId)
             .orElseThrow(() -> new SoolSoolException(NOT_RECEIPT_FOUND));
 
@@ -52,7 +52,7 @@ public class ReceiptService {
             throw new SoolSoolException(NOT_EQUALS_MEMBER);
         }
 
-        return ReceiptResponse.from(receipt);
+        return ReceiptDetailResponse.from(receipt);
     }
 
     @Transactional
@@ -63,7 +63,7 @@ public class ReceiptService {
     ) {
         final Receipt receipt = receiptRepository.findById(receiptId)
             .orElseThrow(() -> new SoolSoolException(NOT_RECEIPT_FOUND));
-        final ReceiptStatus receiptStatus = receiptStatusRepository.findByType(receiptStatusType)
+        final ReceiptStatus receiptStatus = receiptStatusCache.findByType(receiptStatusType)
             .orElseThrow(() -> new SoolSoolException(ReceiptErrorCode.NOT_RECEIPT_TYPE_FOUND));
 
         if (!Objects.equals(receipt.getMemberId(), memberId)) {

--- a/src/main/java/com/woowacamp/soolsool/core/receipt/service/ReceiptService.java
+++ b/src/main/java/com/woowacamp/soolsool/core/receipt/service/ReceiptService.java
@@ -11,9 +11,11 @@ import com.woowacamp.soolsool.core.member.domain.Member;
 import com.woowacamp.soolsool.core.member.repository.MemberRepository;
 import com.woowacamp.soolsool.core.receipt.code.ReceiptErrorCode;
 import com.woowacamp.soolsool.core.receipt.domain.Receipt;
+import com.woowacamp.soolsool.core.receipt.domain.ReceiptStatus;
 import com.woowacamp.soolsool.core.receipt.domain.vo.ReceiptStatusType;
 import com.woowacamp.soolsool.core.receipt.dto.response.ReceiptResponse;
 import com.woowacamp.soolsool.core.receipt.repository.ReceiptRepository;
+import com.woowacamp.soolsool.core.receipt.repository.ReceiptStatusRepository;
 import com.woowacamp.soolsool.global.exception.SoolSoolException;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
@@ -26,6 +28,7 @@ public class ReceiptService {
 
     private final ReceiptMapper receiptMapper;
     private final ReceiptRepository receiptRepository;
+    private final ReceiptStatusRepository receiptStatusRepository;
     private final CartItemRepository cartItemRepository;
     private final MemberRepository memberRepository;
 
@@ -56,16 +59,18 @@ public class ReceiptService {
     public void modifyReceiptStatus(
         final Long memberId,
         final Long receiptId,
-        final ReceiptStatusType type
+        final ReceiptStatusType receiptStatusType
     ) {
         final Receipt receipt = receiptRepository.findById(receiptId)
             .orElseThrow(() -> new SoolSoolException(NOT_RECEIPT_FOUND));
+        final ReceiptStatus receiptStatus = receiptStatusRepository.findByType(receiptStatusType)
+            .orElseThrow(() -> new SoolSoolException(ReceiptErrorCode.NOT_RECEIPT_TYPE_FOUND));
 
         if (!Objects.equals(receipt.getMemberId(), memberId)) {
             throw new SoolSoolException(NOT_EQUALS_MEMBER);
         }
 
-        receipt.updateStatus(type);
+        receipt.updateStatus(receiptStatus);
     }
 
     @Transactional(readOnly = true)

--- a/src/test/java/com/woowacamp/soolsool/acceptance/PayAcceptanceTest.java
+++ b/src/test/java/com/woowacamp/soolsool/acceptance/PayAcceptanceTest.java
@@ -15,6 +15,7 @@ import com.woowacamp.soolsool.core.member.dto.response.MemberDetailResponse;
 import com.woowacamp.soolsool.core.payment.dto.request.PayOrderRequest;
 import com.woowacamp.soolsool.core.payment.dto.response.PayReadyResponse;
 import com.woowacamp.soolsool.core.payment.dto.response.PaySuccessResponse;
+import com.woowacamp.soolsool.core.receipt.dto.response.ReceiptResponse;
 import com.woowacamp.soolsool.global.common.ApiResponse;
 import io.restassured.RestAssured;
 import io.restassured.common.mapper.TypeRef;
@@ -93,5 +94,49 @@ class PayAcceptanceTest extends AcceptanceTest {
 
         MemberDetailResponse memberDetailResponse = RestMemberFixture.회원_정보_조회(김배달_토큰);
         assertThat(memberDetailResponse.getMileage()).isEqualTo("9000");
+    }
+
+    @Test
+    @DisplayName("결제를 취소한다.")
+    void cancel() {
+        /* given */
+        String 김배달_토큰 = RestAuthFixture.로그인_김배달_구매자();
+        Long 김배달_주문서 = RestReceiptFixture.주문서_생성(김배달_토큰);
+        RestPayFixture.결제_준비(김배달_토큰, 김배달_주문서);
+
+        /* when */
+        RestAssured
+            .given().log().all()
+            .header(AUTHORIZATION, BEARER + 김배달_토큰)
+            .contentType(APPLICATION_JSON_VALUE)
+            .when().get("/pay/cancel/{receiptId}", 김배달_주문서)
+            .then();
+
+        /* then */
+        ReceiptResponse 주문서_조회 = RestReceiptFixture.주문서_조회(김배달_토큰, 김배달_주문서);
+
+        assertThat(주문서_조회.getReceiptStatus()).isEqualTo("CANCELED");
+    }
+
+    @Test
+    @DisplayName("결제를 실패한다.")
+    void fail() {
+        /* given */
+        String 김배달_토큰 = RestAuthFixture.로그인_김배달_구매자();
+        Long 김배달_주문서 = RestReceiptFixture.주문서_생성(김배달_토큰);
+        RestPayFixture.결제_준비(김배달_토큰, 김배달_주문서);
+
+        /* when */
+        RestAssured
+            .given().log().all()
+            .header(AUTHORIZATION, BEARER + 김배달_토큰)
+            .contentType(APPLICATION_JSON_VALUE)
+            .when().get("/pay/fail/{receiptId}", 김배달_주문서)
+            .then();
+
+        /* then */
+        ReceiptResponse 주문서_조회 = RestReceiptFixture.주문서_조회(김배달_토큰, 김배달_주문서);
+
+        assertThat(주문서_조회.getReceiptStatus()).isEqualTo("CANCELED");
     }
 }

--- a/src/test/java/com/woowacamp/soolsool/acceptance/PayAcceptanceTest.java
+++ b/src/test/java/com/woowacamp/soolsool/acceptance/PayAcceptanceTest.java
@@ -15,7 +15,7 @@ import com.woowacamp.soolsool.core.member.dto.response.MemberDetailResponse;
 import com.woowacamp.soolsool.core.payment.dto.request.PayOrderRequest;
 import com.woowacamp.soolsool.core.payment.dto.response.PayReadyResponse;
 import com.woowacamp.soolsool.core.payment.dto.response.PaySuccessResponse;
-import com.woowacamp.soolsool.core.receipt.dto.response.ReceiptResponse;
+import com.woowacamp.soolsool.core.receipt.dto.response.ReceiptDetailResponse;
 import com.woowacamp.soolsool.global.common.ApiResponse;
 import io.restassured.RestAssured;
 import io.restassured.common.mapper.TypeRef;
@@ -113,7 +113,7 @@ class PayAcceptanceTest extends AcceptanceTest {
             .then();
 
         /* then */
-        ReceiptResponse 주문서_조회 = RestReceiptFixture.주문서_조회(김배달_토큰, 김배달_주문서);
+        ReceiptDetailResponse 주문서_조회 = RestReceiptFixture.주문서_조회(김배달_토큰, 김배달_주문서);
 
         assertThat(주문서_조회.getReceiptStatus()).isEqualTo("CANCELED");
     }
@@ -135,7 +135,7 @@ class PayAcceptanceTest extends AcceptanceTest {
             .then();
 
         /* then */
-        ReceiptResponse 주문서_조회 = RestReceiptFixture.주문서_조회(김배달_토큰, 김배달_주문서);
+        ReceiptDetailResponse 주문서_조회 = RestReceiptFixture.주문서_조회(김배달_토큰, 김배달_주문서);
 
         assertThat(주문서_조회.getReceiptStatus()).isEqualTo("CANCELED");
     }

--- a/src/test/java/com/woowacamp/soolsool/acceptance/ReceiptAcceptanceTest.java
+++ b/src/test/java/com/woowacamp/soolsool/acceptance/ReceiptAcceptanceTest.java
@@ -13,7 +13,7 @@ import com.woowacamp.soolsool.acceptance.fixture.RestLiquorFixture;
 import com.woowacamp.soolsool.acceptance.fixture.RestLiquorStockFixture;
 import com.woowacamp.soolsool.acceptance.fixture.RestMemberFixture;
 import com.woowacamp.soolsool.acceptance.fixture.RestReceiptFixture;
-import com.woowacamp.soolsool.core.receipt.dto.response.ReceiptResponse;
+import com.woowacamp.soolsool.core.receipt.dto.response.ReceiptDetailResponse;
 import com.woowacamp.soolsool.global.common.ApiResponse;
 import io.restassured.RestAssured;
 import io.restassured.common.mapper.TypeRef;
@@ -81,7 +81,7 @@ class ReceiptAcceptanceTest extends AcceptanceTest {
         // then
         assertThat(detailReceiptResponse.statusCode()).isEqualTo(OK.value());
 
-        assertThat(detailReceiptResponse.body().as(new TypeRef<ApiResponse<ReceiptResponse>>() {
+        assertThat(detailReceiptResponse.body().as(new TypeRef<ApiResponse<ReceiptDetailResponse>>() {
             })
             .getMessage())
             .isEqualTo(RECEIPT_FOUND.getMessage());

--- a/src/test/java/com/woowacamp/soolsool/acceptance/fixture/RestReceiptFixture.java
+++ b/src/test/java/com/woowacamp/soolsool/acceptance/fixture/RestReceiptFixture.java
@@ -3,6 +3,7 @@ package com.woowacamp.soolsool.acceptance.fixture;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
+import com.woowacamp.soolsool.core.receipt.dto.response.ReceiptResponse;
 import io.restassured.RestAssured;
 
 public abstract class RestReceiptFixture extends RestFixture {
@@ -15,5 +16,15 @@ public abstract class RestReceiptFixture extends RestFixture {
             .when().post("/receipts")
             .then().log().all()
             .extract().header("Location").split("/")[2]);
+    }
+
+    public static ReceiptResponse 주문서_조회(String 토큰, Long 주문서) {
+        return RestAssured
+            .given().log().all()
+            .contentType(APPLICATION_JSON_VALUE)
+            .header(AUTHORIZATION, BEARER + 토큰)
+            .when().get("/receipts/{receiptId}", 주문서)
+            .then().log().all()
+            .extract().jsonPath().getObject("data", ReceiptResponse.class);
     }
 }

--- a/src/test/java/com/woowacamp/soolsool/acceptance/fixture/RestReceiptFixture.java
+++ b/src/test/java/com/woowacamp/soolsool/acceptance/fixture/RestReceiptFixture.java
@@ -3,7 +3,7 @@ package com.woowacamp.soolsool.acceptance.fixture;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
-import com.woowacamp.soolsool.core.receipt.dto.response.ReceiptResponse;
+import com.woowacamp.soolsool.core.receipt.dto.response.ReceiptDetailResponse;
 import io.restassured.RestAssured;
 
 public abstract class RestReceiptFixture extends RestFixture {
@@ -18,13 +18,13 @@ public abstract class RestReceiptFixture extends RestFixture {
             .extract().header("Location").split("/")[2]);
     }
 
-    public static ReceiptResponse 주문서_조회(String 토큰, Long 주문서) {
+    public static ReceiptDetailResponse 주문서_조회(String 토큰, Long 주문서) {
         return RestAssured
             .given().log().all()
             .contentType(APPLICATION_JSON_VALUE)
             .header(AUTHORIZATION, BEARER + 토큰)
             .when().get("/receipts/{receiptId}", 주문서)
             .then().log().all()
-            .extract().jsonPath().getObject("data", ReceiptResponse.class);
+            .extract().jsonPath().getObject("data", ReceiptDetailResponse.class);
     }
 }

--- a/src/test/java/com/woowacamp/soolsool/core/receipt/repository/ReceiptRepositoryTest.java
+++ b/src/test/java/com/woowacamp/soolsool/core/receipt/repository/ReceiptRepositoryTest.java
@@ -1,0 +1,48 @@
+package com.woowacamp.soolsool.core.receipt.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.woowacamp.soolsool.core.receipt.domain.Receipt;
+import com.woowacamp.soolsool.core.receipt.domain.ReceiptStatus;
+import com.woowacamp.soolsool.core.receipt.domain.vo.ReceiptStatusType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.jdbc.Sql;
+
+@DataJpaTest
+@Sql({
+    "/member-type.sql", "/member.sql",
+    "/liquor-type.sql", "/liquor.sql",
+    "/cart-item.sql",
+    "/receipt-type.sql", "/receipt.sql"
+})
+@DisplayName("통합 테스트: ReceiptRepository")
+class ReceiptRepositoryTest {
+
+    @Autowired
+    ReceiptRepository receiptRepository;
+
+    @Autowired
+    ReceiptStatusRepository receiptStatusRepository;
+
+    @Test
+    @DisplayName("주문서 상태를 변경한다.")
+    void updateReceiptStatus() {
+        /* given */
+        Receipt receipt = receiptRepository.findById(1L)
+            .orElseThrow(() -> new RuntimeException("주문서가 존재하지 않습니다."));
+        ReceiptStatus receiptStatus = receiptStatusRepository
+            .findByType(ReceiptStatusType.CANCELED)
+            .orElseThrow(() -> new RuntimeException("주문서 상태가 존재하지 않습니다."));
+
+        /* when */
+        receipt.updateStatus(receiptStatus);
+
+        /* then */
+        Receipt result = receiptRepository.findById(1L)
+            .orElseThrow(() -> new RuntimeException("주문서가 존재하지 않습니다."));
+        assertThat(result.getReceiptStatus()).isEqualTo("CANCELED");
+    }
+}

--- a/src/test/java/com/woowacamp/soolsool/core/receipt/repository/ReceiptStatusRepositoryTest.java
+++ b/src/test/java/com/woowacamp/soolsool/core/receipt/repository/ReceiptStatusRepositoryTest.java
@@ -34,5 +34,4 @@ class ReceiptStatusRepositoryTest {
         /* then */
         assertThat(receiptStatus).isPresent();
     }
-
 }

--- a/src/test/java/com/woowacamp/soolsool/core/receipt/service/ReceiptServiceIntegrationTest.java
+++ b/src/test/java/com/woowacamp/soolsool/core/receipt/service/ReceiptServiceIntegrationTest.java
@@ -13,7 +13,7 @@ import com.woowacamp.soolsool.core.liquor.repository.LiquorBrewCache;
 import com.woowacamp.soolsool.core.liquor.repository.LiquorRegionCache;
 import com.woowacamp.soolsool.core.liquor.repository.LiquorStatusCache;
 import com.woowacamp.soolsool.core.liquor.service.LiquorService;
-import com.woowacamp.soolsool.core.receipt.dto.response.ReceiptResponse;
+import com.woowacamp.soolsool.core.receipt.dto.response.ReceiptDetailResponse;
 import com.woowacamp.soolsool.core.receipt.repository.ReceiptStatusCache;
 import com.woowacamp.soolsool.global.exception.SoolSoolException;
 import org.junit.jupiter.api.DisplayName;
@@ -100,7 +100,7 @@ class ReceiptServiceIntegrationTest {
         Long 김배달_주문서 = 1L;
 
         // when
-        ReceiptResponse receipt = receiptService.findReceipt(김배달, 김배달_주문서);
+        ReceiptDetailResponse receipt = receiptService.findReceipt(김배달, 김배달_주문서);
         // then
         assertThat(receipt).extracting("id").isEqualTo(김배달_주문서);
     }
@@ -160,7 +160,7 @@ class ReceiptServiceIntegrationTest {
         receiptService.modifyReceiptStatus(김배달, 김배달_주문서, COMPLETED);
 
         // then
-        ReceiptResponse receipt = receiptService.findReceipt(김배달, 김배달_주문서);
+        ReceiptDetailResponse receipt = receiptService.findReceipt(김배달, 김배달_주문서);
         assertThat(receipt.getReceiptStatus()).isEqualTo("COMPLETED");
     }
 


### PR DESCRIPTION
## ♻️ 변경 사항

```
ex)
### docs: PULL_REQUEST_TEMPLATE.md 작성 ... [a6684f7](https://github.com/five-uys/test/commit/7625214be558f7496cca1dec633f02942799dff1)

* PR 생성 시 자동으로 적용될 템플릿
* ...
```
결제 실패 및 취소 시 주문을 취소한다.

<br>

## 📌 참고 사항

```
ex)
* 결제 부분 로직이 복잡한데, ~~~ 이유로 ~~~ 를 구현하기 위해 불가피했읍니다.
* ...
```


<br>

## 🎸 기타

```
ex) 닫을 이슈가 있다면,
closes #이슈번호
```
closes #166 
