### PR TITLE
feat: 주문서가 파기된 후 주문서 상태를 변경하는 로직 추가

### DIFF
--- a/src/main/java/com/woowacamp/soolsool/SoolsoolApplication.java
+++ b/src/main/java/com/woowacamp/soolsool/SoolsoolApplication.java
@@ -4,9 +4,11 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableAsync;
 
-@EnableJpaAuditing
+@EnableAsync
 @EnableCaching
+@EnableJpaAuditing
 @SpringBootApplication
 public class SoolsoolApplication {
 

--- a/src/main/java/com/woowacamp/soolsool/core/receipt/event/ReceiptExpiredEvent.java
+++ b/src/main/java/com/woowacamp/soolsool/core/receipt/event/ReceiptExpiredEvent.java
@@ -1,9 +1,7 @@
 package com.woowacamp.soolsool.core.receipt.event;
 
 import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
 @Getter
 public class ReceiptExpiredEvent {
 

--- a/src/main/java/com/woowacamp/soolsool/core/receipt/event/ReceiptExpiredEvent.java
+++ b/src/main/java/com/woowacamp/soolsool/core/receipt/event/ReceiptExpiredEvent.java
@@ -1,0 +1,17 @@
+package com.woowacamp.soolsool.core.receipt.event;
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Getter
+public class ReceiptExpiredEvent {
+
+    private final Long receiptId;
+    private final Long memberId;
+
+    public ReceiptExpiredEvent(final Long receiptId, final Long memberId) {
+        this.receiptId = receiptId;
+        this.memberId = memberId;
+    }
+}

--- a/src/main/java/com/woowacamp/soolsool/core/receipt/event/listener/ReceiptExpiredEventListener.java
+++ b/src/main/java/com/woowacamp/soolsool/core/receipt/event/listener/ReceiptExpiredEventListener.java
@@ -1,0 +1,26 @@
+package com.woowacamp.soolsool.core.receipt.event.listener;
+
+import com.woowacamp.soolsool.core.receipt.domain.vo.ReceiptStatusType;
+import com.woowacamp.soolsool.core.receipt.event.ReceiptExpiredEvent;
+import com.woowacamp.soolsool.core.receipt.service.ReceiptService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ReceiptExpiredEventListener {
+
+    private final ReceiptService receiptService;
+
+    @Async
+    @EventListener
+    public void expiredListener(final ReceiptExpiredEvent event) {
+        receiptService.modifyReceiptStatus(
+            event.getMemberId(), event.getReceiptId(), ReceiptStatusType.EXPIRED
+        );
+    }
+}

--- a/src/main/java/com/woowacamp/soolsool/core/receipt/event/listener/ReceiptExpiredEventListener.java
+++ b/src/main/java/com/woowacamp/soolsool/core/receipt/event/listener/ReceiptExpiredEventListener.java
@@ -19,6 +19,8 @@ public class ReceiptExpiredEventListener {
     @Async
     @EventListener
     public void expiredListener(final ReceiptExpiredEvent event) {
+        log.info("Member {}'s Receipt {} Expired", event.getMemberId(), event.getReceiptId());
+
         receiptService.modifyReceiptStatus(
             event.getMemberId(), event.getReceiptId(), ReceiptStatusType.EXPIRED
         );

--- a/src/main/java/com/woowacamp/soolsool/core/receipt/event/listener/ReceiptExpiredEventListener.java
+++ b/src/main/java/com/woowacamp/soolsool/core/receipt/event/listener/ReceiptExpiredEventListener.java
@@ -19,10 +19,10 @@ public class ReceiptExpiredEventListener {
     @Async
     @EventListener
     public void expiredListener(final ReceiptExpiredEvent event) {
-        log.info("Member {}'s Receipt {} Expired", event.getMemberId(), event.getReceiptId());
-
         receiptService.modifyReceiptStatus(
             event.getMemberId(), event.getReceiptId(), ReceiptStatusType.EXPIRED
         );
+
+        log.info("Member {}'s Receipt {} Expired", event.getMemberId(), event.getReceiptId());
     }
 }

--- a/src/main/java/com/woowacamp/soolsool/core/receipt/repository/redisson/ReceiptRedisRepository.java
+++ b/src/main/java/com/woowacamp/soolsool/core/receipt/repository/redisson/ReceiptRedisRepository.java
@@ -34,6 +34,6 @@ public class ReceiptRedisRepository {
 
         receiptCache.put(receiptId, memberId, minutes, TimeUnit.MINUTES);
 
-        log.info("Complete save Member {}'s Receipt {} to Redis", memberId, receiptCache);
+        log.info("Complete to save Member {}'s Receipt {} to Redis", memberId, receiptCache);
     }
 }

--- a/src/main/java/com/woowacamp/soolsool/core/receipt/repository/redisson/ReceiptRedisRepository.java
+++ b/src/main/java/com/woowacamp/soolsool/core/receipt/repository/redisson/ReceiptRedisRepository.java
@@ -1,0 +1,37 @@
+package com.woowacamp.soolsool.core.receipt.repository.redisson;
+
+import com.woowacamp.soolsool.core.receipt.event.ReceiptExpiredEvent;
+import java.util.concurrent.TimeUnit;
+import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RMapCache;
+import org.redisson.api.RedissonClient;
+import org.redisson.api.map.event.EntryExpiredListener;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class ReceiptRedisRepository {
+
+    private static final String RECEIPT_EXPIRED_KEY = "RECEIPT_EXPIRED";
+
+    private final RedissonClient redissonClient;
+
+    public ReceiptRedisRepository(
+        final RedissonClient redissonClient,
+        final ApplicationEventPublisher publisher
+    ) {
+        redissonClient.getMapCache(RECEIPT_EXPIRED_KEY)
+            .addListenerAsync((EntryExpiredListener<Long, Long>) event
+                -> publisher.publishEvent(new ReceiptExpiredEvent(event.getKey(), event.getValue()))
+            );
+
+        this.redissonClient = redissonClient;
+    }
+
+    public void addExpiredEvent(final Long receiptId, final Long memberId, final long minutes) {
+        final RMapCache<Long, Long> receiptCache = redissonClient.getMapCache(RECEIPT_EXPIRED_KEY);
+
+        receiptCache.put(receiptId, memberId, minutes, TimeUnit.MINUTES);
+    }
+}

--- a/src/main/java/com/woowacamp/soolsool/core/receipt/repository/redisson/ReceiptRedisRepository.java
+++ b/src/main/java/com/woowacamp/soolsool/core/receipt/repository/redisson/ReceiptRedisRepository.java
@@ -33,5 +33,7 @@ public class ReceiptRedisRepository {
         final RMapCache<Long, Long> receiptCache = redissonClient.getMapCache(RECEIPT_EXPIRED_KEY);
 
         receiptCache.put(receiptId, memberId, minutes, TimeUnit.MINUTES);
+
+        log.info("Complete save Member {}'s Receipt {} to Redis", memberId, receiptCache);
     }
 }

--- a/src/main/java/com/woowacamp/soolsool/core/receipt/service/ReceiptService.java
+++ b/src/main/java/com/woowacamp/soolsool/core/receipt/service/ReceiptService.java
@@ -16,6 +16,7 @@ import com.woowacamp.soolsool.core.receipt.domain.vo.ReceiptStatusType;
 import com.woowacamp.soolsool.core.receipt.dto.response.ReceiptDetailResponse;
 import com.woowacamp.soolsool.core.receipt.repository.ReceiptRepository;
 import com.woowacamp.soolsool.core.receipt.repository.ReceiptStatusCache;
+import com.woowacamp.soolsool.core.receipt.repository.redisson.ReceiptRedisRepository;
 import com.woowacamp.soolsool.global.exception.SoolSoolException;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
@@ -26,21 +27,29 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class ReceiptService {
 
+    private static final int RECEIPT_EXPIRED_MINUTES = 5;
+
     private final ReceiptMapper receiptMapper;
     private final ReceiptRepository receiptRepository;
     private final ReceiptStatusCache receiptStatusCache;
     private final CartItemRepository cartItemRepository;
     private final MemberRepository memberRepository;
 
+    private final ReceiptRedisRepository receiptRedisRepository;
+
     @Transactional
     public Long addReceipt(final Long memberId) {
         final Member member = memberRepository.findById(memberId)
             .orElseThrow(() -> new SoolSoolException(ReceiptErrorCode.MEMBER_NO_INFORMATION));
 
-        final Cart cart =
-            new Cart(memberId, cartItemRepository.findAllByMemberId(memberId));
+        final Cart cart = new Cart(memberId, cartItemRepository.findAllByMemberId(memberId));
 
-        return receiptRepository.save(receiptMapper.mapFrom(cart, member.getMileage())).getId();
+        final Long receiptId = receiptRepository.save(
+            receiptMapper.mapFrom(cart, member.getMileage())).getId();
+
+        receiptRedisRepository.addExpiredEvent(receiptId, memberId, RECEIPT_EXPIRED_MINUTES);
+
+        return receiptId;
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/woowacamp/soolsool/global/config/RedissonConfig.java
+++ b/src/main/java/com/woowacamp/soolsool/global/config/RedissonConfig.java
@@ -25,6 +25,8 @@ public class RedissonConfig {
     public RedissonClient getRedissonConfig() {
         final Config config = new Config();
         config
+            .setMinCleanUpDelay(0)
+            .setMaxCleanUpDelay(0)
             .useSingleServer()
             .setAddress("redis://" + host + ":" + port);
 

--- a/src/test/java/com/woowacamp/soolsool/acceptance/ReceiptAcceptanceTest.java
+++ b/src/test/java/com/woowacamp/soolsool/acceptance/ReceiptAcceptanceTest.java
@@ -67,7 +67,7 @@ class ReceiptAcceptanceTest extends AcceptanceTest {
     @DisplayName("성공: 주문서를 조회한다.")
     void findReceiptSuccess() {
         // given
-        final Long 주문서_Id = RestReceiptFixture.주문서_생성(김배달_토큰);
+        Long 주문서_Id = RestReceiptFixture.주문서_생성(김배달_토큰);
 
         // when
         ExtractableResponse<Response> detailReceiptResponse = RestAssured

--- a/src/test/java/com/woowacamp/soolsool/core/receipt/repository/redisson/ReceiptRedisRepositoryTest.java
+++ b/src/test/java/com/woowacamp/soolsool/core/receipt/repository/redisson/ReceiptRedisRepositoryTest.java
@@ -1,0 +1,28 @@
+package com.woowacamp.soolsool.core.receipt.repository.redisson;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+@DisplayName("통합 테스트 : ReceiptRedisRepository")
+class ReceiptRedisRepositoryTest {
+
+    @Autowired
+    ReceiptRedisRepository receiptRedisRepository;
+
+    @Test
+    @DisplayName("5분 후 파기되는 주문서를 발행한다.")
+    void addExpiredEvent() {
+        // given
+        Long receiptId = 1L;
+        Long memberId = 1L;
+
+        // when & then
+        assertDoesNotThrow(()
+            -> receiptRedisRepository.addExpiredEvent(receiptId, memberId, 5));
+    }
+}

--- a/src/test/java/com/woowacamp/soolsool/core/receipt/service/ReceiptServiceIntegrationTest.java
+++ b/src/test/java/com/woowacamp/soolsool/core/receipt/service/ReceiptServiceIntegrationTest.java
@@ -15,9 +15,12 @@ import com.woowacamp.soolsool.core.liquor.repository.LiquorStatusCache;
 import com.woowacamp.soolsool.core.liquor.service.LiquorService;
 import com.woowacamp.soolsool.core.receipt.dto.response.ReceiptDetailResponse;
 import com.woowacamp.soolsool.core.receipt.repository.ReceiptStatusCache;
+import com.woowacamp.soolsool.core.receipt.repository.redisson.ReceiptRedisRepository;
+import com.woowacamp.soolsool.global.config.RedissonConfig;
 import com.woowacamp.soolsool.global.exception.SoolSoolException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.redisson.api.RedissonClient;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
@@ -26,7 +29,8 @@ import org.springframework.test.context.jdbc.Sql;
 @DataJpaTest
 @Import({ReceiptService.class, CartService.class, LiquorService.class,
     ReceiptMapper.class, LiquorBrewCache.class, LiquorStatusCache.class,
-    LiquorRegionCache.class, ReceiptStatusCache.class})
+    LiquorRegionCache.class, ReceiptStatusCache.class,
+    RedissonConfig.class, ReceiptRedisRepository.class})
 @DisplayName("통합 테스트: ReceiptService")
 class ReceiptServiceIntegrationTest {
 


### PR DESCRIPTION
## ♻️ 변경 사항

주문서가 파기된 후 주문서 상태를 변경하는 로직을 추가한다.

<br>

## 📌 참고 사항

주문 파기 플로우
1. 주문서를 발행한다.
2. TTL을 5분으로 설정한 뒤 redis에 receiptId를 저장한다.
3. TTL 이후 데이터가 삭제되면 `ReceiptExpiredEvent`를 pub 한다.
4. `ReceiptExpiredEventListener`가 `ReceiptExpiredEvent`를 sub 하고, `ReceiptService`의 `modifyReceiptStatus`를 호출한다.

<br>

## 🎸 기타

closes #172 
