### PR TITLE
feat: 지연 쓰기 구현 및 클릭률 조회 기준을 Redis로 변경

### DIFF
--- a/src/main/java/com/woowacamp/soolsool/core/liquor/code/LiquorErrorCode.java
+++ b/src/main/java/com/woowacamp/soolsool/core/liquor/code/LiquorErrorCode.java
@@ -41,6 +41,7 @@ public enum LiquorErrorCode implements ErrorCode {
     NOT_LIQUOR_CTR_FOUND(NOT_FOUND.value(), "L117", "술 클릭률이 존재하지 않습니다."),
 
     INTERRUPTED_THREAD(500, "L118", "예상치 못한 예외가 발생했습니다."),
+    REDIS_HAS_NOT_CTR(500, "L119", "예상치 못한 예외가 발생했습니다."),
     ;
 
     private final int status;

--- a/src/main/java/com/woowacamp/soolsool/core/liquor/domain/LiquorCtr.java
+++ b/src/main/java/com/woowacamp/soolsool/core/liquor/domain/LiquorCtr.java
@@ -55,6 +55,14 @@ public class LiquorCtr extends BaseEntity {
         this.click = click.increaseOne();
     }
 
+    public void saveImpression(final LiquorCtrImpression impression) {
+        this.impression = impression;
+    }
+
+    public void saveClick(final LiquorCtrClick click) {
+        this.click = click;
+    }
+
     public double getCtr() {
         if (impression.getImpression() == 0) {
             throw new SoolSoolException(LiquorCtrErrorCode.DIVIDE_BY_ZERO_IMPRESSION);

--- a/src/main/java/com/woowacamp/soolsool/core/liquor/event/LiquorCtrExpiredEvent.java
+++ b/src/main/java/com/woowacamp/soolsool/core/liquor/event/LiquorCtrExpiredEvent.java
@@ -1,0 +1,15 @@
+package com.woowacamp.soolsool.core.liquor.event;
+
+import com.woowacamp.soolsool.core.liquor.domain.vo.LiquorCtrClick;
+import com.woowacamp.soolsool.core.liquor.domain.vo.LiquorCtrImpression;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class LiquorCtrExpiredEvent {
+
+    private final Long liquorId;
+    private final LiquorCtrImpression impression;
+    private final LiquorCtrClick click;
+}

--- a/src/main/java/com/woowacamp/soolsool/core/liquor/event/listener/LiquorCtrExpiredEventListener.java
+++ b/src/main/java/com/woowacamp/soolsool/core/liquor/event/listener/LiquorCtrExpiredEventListener.java
@@ -1,0 +1,25 @@
+package com.woowacamp.soolsool.core.liquor.event.listener;
+
+import com.woowacamp.soolsool.core.liquor.event.LiquorCtrExpiredEvent;
+import com.woowacamp.soolsool.core.liquor.service.LiquorCtrService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class LiquorCtrExpiredEventListener {
+
+    private final LiquorCtrService liquorCtrService;
+
+    @Async
+    @EventListener
+    public void expiredListener(final LiquorCtrExpiredEvent event) {
+        liquorCtrService.writeBackLiquorCtr(
+            event.getLiquorId(),
+            event.getImpression(),
+            event.getClick()
+        );
+    }
+}

--- a/src/main/java/com/woowacamp/soolsool/core/liquor/infra/RedisLiquorCtr.java
+++ b/src/main/java/com/woowacamp/soolsool/core/liquor/infra/RedisLiquorCtr.java
@@ -17,4 +17,8 @@ public class RedisLiquorCtr {
     public RedisLiquorCtr increaseClick() {
         return new RedisLiquorCtr(impression, click + 1);
     }
+
+    public RedisLiquorCtr synchronizedWithDatabase(final Long impression, final Long click) {
+        return new RedisLiquorCtr(this.impression + impression, this.click + click);
+    }
 }

--- a/src/main/java/com/woowacamp/soolsool/core/liquor/infra/RedisLiquorCtr.java
+++ b/src/main/java/com/woowacamp/soolsool/core/liquor/infra/RedisLiquorCtr.java
@@ -1,0 +1,20 @@
+package com.woowacamp.soolsool.core.liquor.infra;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class RedisLiquorCtr {
+
+    private final Long impression;
+    private final Long click;
+
+    public RedisLiquorCtr increaseImpression() {
+        return new RedisLiquorCtr(impression + 1, click);
+    }
+
+    public RedisLiquorCtr increaseClick() {
+        return new RedisLiquorCtr(impression, click + 1);
+    }
+}

--- a/src/main/java/com/woowacamp/soolsool/core/liquor/repository/redisson/LiquorCtrRedisRepository.java
+++ b/src/main/java/com/woowacamp/soolsool/core/liquor/repository/redisson/LiquorCtrRedisRepository.java
@@ -1,0 +1,113 @@
+package com.woowacamp.soolsool.core.liquor.repository.redisson;
+
+import com.woowacamp.soolsool.core.liquor.code.LiquorErrorCode;
+import com.woowacamp.soolsool.core.liquor.domain.vo.LiquorCtrClick;
+import com.woowacamp.soolsool.core.liquor.domain.vo.LiquorCtrImpression;
+import com.woowacamp.soolsool.core.liquor.infra.RedisLiquorCtr;
+import com.woowacamp.soolsool.global.exception.SoolSoolException;
+import com.woowacamp.soolsool.global.infra.LockType;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RLock;
+import org.redisson.api.RMapCache;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class LiquorCtrRedisRepository {
+
+    private static final String LIQUOR_CTR_KEY = "LIQUOR_CTR";
+    private static final long LOCK_WAIT_TIME = 3L;
+    private static final long LOCK_LEASE_TIME = 3L;
+
+    private final RedissonClient redissonClient;
+
+    public void save(
+        final Long liquorId,
+        final LiquorCtrImpression impression,
+        final LiquorCtrClick click
+    ) {
+        final RMapCache<Long, RedisLiquorCtr> liquorCtr =
+            redissonClient.getMapCache(LIQUOR_CTR_KEY);
+
+        liquorCtr.put(liquorId, new RedisLiquorCtr(impression.getImpression(), click.getClick()));
+    }
+
+    public LiquorCtrImpression findImpressionByLiquorId(final Long liquorId) {
+        final RMapCache<Long, RedisLiquorCtr> liquorCtr =
+            redissonClient.getMapCache(LIQUOR_CTR_KEY);
+
+        validateExistsCtr(liquorId, liquorCtr);
+
+        return new LiquorCtrImpression(liquorCtr.get(liquorId).getImpression());
+    }
+
+    public LiquorCtrClick findClickByLiquorId(final Long liquorId) {
+        final RMapCache<Long, RedisLiquorCtr> liquorCtr =
+            redissonClient.getMapCache(LIQUOR_CTR_KEY);
+
+        validateExistsCtr(liquorId, liquorCtr);
+
+        return new LiquorCtrClick(liquorCtr.get(liquorId).getClick());
+    }
+
+    public void increaseImpression(final Long liquorId) {
+        final RLock rLock = redissonClient.getLock(LockType.LIQUOR_CTR.getPrefix() + liquorId);
+
+        try {
+            rLock.tryLock(LOCK_WAIT_TIME, LOCK_LEASE_TIME, TimeUnit.SECONDS);
+
+            final RMapCache<Long, RedisLiquorCtr> liquorCtr =
+                redissonClient.getMapCache(LIQUOR_CTR_KEY);
+
+            validateExistsCtr(liquorId, liquorCtr);
+
+            final RedisLiquorCtr redisLiquorCtr = liquorCtr.get(liquorId);
+
+            liquorCtr.replace(liquorId, redisLiquorCtr.increaseImpression());
+        } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+
+            throw new SoolSoolException(LiquorErrorCode.INTERRUPTED_THREAD);
+        } finally {
+            rLock.unlock();
+        }
+    }
+
+    public void increaseClick(final Long liquorId) {
+        final RLock rLock = redissonClient.getLock(LockType.LIQUOR_CTR.getPrefix() + liquorId);
+
+        try {
+            rLock.tryLock(LOCK_WAIT_TIME, LOCK_LEASE_TIME, TimeUnit.SECONDS);
+
+            final RMapCache<Long, RedisLiquorCtr> liquorCtr =
+                redissonClient.getMapCache(LIQUOR_CTR_KEY);
+
+            validateExistsCtr(liquorId, liquorCtr);
+
+            final RedisLiquorCtr redisLiquorCtr = liquorCtr.get(liquorId);
+
+            liquorCtr.replace(liquorId, redisLiquorCtr.increaseClick());
+        } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+
+            throw new SoolSoolException(LiquorErrorCode.INTERRUPTED_THREAD);
+        } finally {
+            rLock.unlock();
+        }
+    }
+
+    private void validateExistsCtr(
+        final Long liquorId,
+        final RMapCache<Long, RedisLiquorCtr> liquorCtr
+    ) {
+        if (!liquorCtr.containsKey(liquorId)) {
+            log.error("Redis에 LiquorId\"{}\"를 Key로 갖는 데이터가 존재하지 않습니다.", liquorId);
+
+            throw new SoolSoolException(LiquorErrorCode.REDIS_HAS_NOT_CTR);
+        }
+    }
+}

--- a/src/main/java/com/woowacamp/soolsool/core/liquor/repository/redisson/LiquorCtrRedisRepository.java
+++ b/src/main/java/com/woowacamp/soolsool/core/liquor/repository/redisson/LiquorCtrRedisRepository.java
@@ -1,39 +1,65 @@
 package com.woowacamp.soolsool.core.liquor.repository.redisson;
 
+import com.woowacamp.soolsool.core.liquor.code.LiquorCtrErrorCode;
 import com.woowacamp.soolsool.core.liquor.code.LiquorErrorCode;
 import com.woowacamp.soolsool.core.liquor.domain.vo.LiquorCtrClick;
 import com.woowacamp.soolsool.core.liquor.domain.vo.LiquorCtrImpression;
+import com.woowacamp.soolsool.core.liquor.event.LiquorCtrExpiredEvent;
 import com.woowacamp.soolsool.core.liquor.infra.RedisLiquorCtr;
 import com.woowacamp.soolsool.global.exception.SoolSoolException;
 import com.woowacamp.soolsool.global.infra.LockType;
 import java.util.concurrent.TimeUnit;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.redisson.api.RLock;
 import org.redisson.api.RMapCache;
 import org.redisson.api.RedissonClient;
+import org.redisson.api.map.event.EntryExpiredListener;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
 
 @Component
 @Slf4j
-@RequiredArgsConstructor
 public class LiquorCtrRedisRepository {
 
     private static final String LIQUOR_CTR_KEY = "LIQUOR_CTR";
     private static final long LOCK_WAIT_TIME = 3L;
     private static final long LOCK_LEASE_TIME = 3L;
+    private static final long LIQUOR_CTR_TTL = 5L;
 
     private final RedissonClient redissonClient;
 
-    public void save(
-        final Long liquorId,
-        final LiquorCtrImpression impression,
-        final LiquorCtrClick click
+    public LiquorCtrRedisRepository(
+        final RedissonClient redissonClient,
+        final ApplicationEventPublisher publisher
     ) {
+        redissonClient.getMapCache(LIQUOR_CTR_KEY)
+            .addListener((EntryExpiredListener<Long, RedisLiquorCtr>) event ->
+                publisher.publishEvent(new LiquorCtrExpiredEvent(
+                    event.getKey(),
+                    new LiquorCtrImpression(event.getValue().getImpression()),
+                    new LiquorCtrClick(event.getValue().getClick()))
+                )
+            );
+
+        this.redissonClient = redissonClient;
+    }
+
+    public double getCtr(final Long liquorId) {
         final RMapCache<Long, RedisLiquorCtr> liquorCtr =
             redissonClient.getMapCache(LIQUOR_CTR_KEY);
 
-        liquorCtr.put(liquorId, new RedisLiquorCtr(impression.getImpression(), click.getClick()));
+        validateExistsCtr(liquorId, liquorCtr);
+
+        final Long click = liquorCtr.get(liquorId).getClick();
+        final Long impression = liquorCtr.get(liquorId).getImpression();
+
+        if (impression == 0) {
+            throw new SoolSoolException(LiquorCtrErrorCode.DIVIDE_BY_ZERO_IMPRESSION);
+        }
+
+        final double ratio = (double) click / impression;
+
+        return Math.round(ratio * 100) / 100.0;
     }
 
     public LiquorCtrImpression findImpressionByLiquorId(final Long liquorId) {
@@ -63,12 +89,14 @@ public class LiquorCtrRedisRepository {
             final RMapCache<Long, RedisLiquorCtr> liquorCtr =
                 redissonClient.getMapCache(LIQUOR_CTR_KEY);
 
-            validateExistsCtr(liquorId, liquorCtr);
+            initLiquorCtrIfAbsent(liquorCtr, liquorId);
 
             final RedisLiquorCtr redisLiquorCtr = liquorCtr.get(liquorId);
 
             liquorCtr.replace(liquorId, redisLiquorCtr.increaseImpression());
         } catch (final InterruptedException e) {
+            log.error("노출수 갱신에 실패했습니다. | liquorId : {}", liquorId);
+
             Thread.currentThread().interrupt();
 
             throw new SoolSoolException(LiquorErrorCode.INTERRUPTED_THREAD);
@@ -86,18 +114,48 @@ public class LiquorCtrRedisRepository {
             final RMapCache<Long, RedisLiquorCtr> liquorCtr =
                 redissonClient.getMapCache(LIQUOR_CTR_KEY);
 
-            validateExistsCtr(liquorId, liquorCtr);
+            initLiquorCtrIfAbsent(liquorCtr, liquorId);
 
             final RedisLiquorCtr redisLiquorCtr = liquorCtr.get(liquorId);
 
             liquorCtr.replace(liquorId, redisLiquorCtr.increaseClick());
         } catch (final InterruptedException e) {
+            log.error("클릭수 갱신에 실패했습니다. | liquorId : {}", liquorId);
+
             Thread.currentThread().interrupt();
 
             throw new SoolSoolException(LiquorErrorCode.INTERRUPTED_THREAD);
         } finally {
             rLock.unlock();
         }
+    }
+
+    public void synchronizedWithDatabase(
+        final Long liquorId,
+        final LiquorCtrImpression impression,
+        final LiquorCtrClick click
+    ) {
+        final RMapCache<Long, RedisLiquorCtr> liquorCtr =
+            redissonClient.getMapCache(LIQUOR_CTR_KEY);
+
+        initLiquorCtrIfAbsent(liquorCtr, liquorId);
+
+        final RedisLiquorCtr synchronizedLiquorCtr = liquorCtr.get(liquorId)
+            .synchronizedWithDatabase(impression.getImpression(), click.getClick());
+
+        liquorCtr.replace(liquorId, synchronizedLiquorCtr);
+    }
+
+    private void initLiquorCtrIfAbsent(
+        final RMapCache<Long, RedisLiquorCtr> liquorCtr,
+        final Long liquorId
+    ) {
+        liquorCtr.putIfAbsent(
+            liquorId,
+            new RedisLiquorCtr(0L, 0L),
+            LIQUOR_CTR_TTL,
+            TimeUnit.MINUTES
+        );
     }
 
     private void validateExistsCtr(

--- a/src/main/java/com/woowacamp/soolsool/core/liquor/service/LiquorCtrService.java
+++ b/src/main/java/com/woowacamp/soolsool/core/liquor/service/LiquorCtrService.java
@@ -1,22 +1,66 @@
 package com.woowacamp.soolsool.core.liquor.service;
 
-import com.woowacamp.soolsool.core.liquor.code.LiquorCtrErrorCode;
+import com.woowacamp.soolsool.core.liquor.code.LiquorErrorCode;
+import com.woowacamp.soolsool.core.liquor.domain.LiquorCtr;
+import com.woowacamp.soolsool.core.liquor.domain.vo.LiquorCtrClick;
+import com.woowacamp.soolsool.core.liquor.domain.vo.LiquorCtrImpression;
 import com.woowacamp.soolsool.core.liquor.repository.LiquorCtrRepository;
+import com.woowacamp.soolsool.core.liquor.repository.redisson.LiquorCtrRedisRepository;
 import com.woowacamp.soolsool.global.exception.SoolSoolException;
+import com.woowacamp.soolsool.global.infra.LockType;
+import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class LiquorCtrService {
 
+    private static final long LOCK_WAIT_TIME = 3L;
+    private static final long LOCK_LEASE_TIME = 3L;
+
     private final LiquorCtrRepository liquorCtrRepository;
+
+    private final LiquorCtrRedisRepository liquorCtrRedisRepository;
+
+    private final RedissonClient redissonClient;
 
     @Transactional(readOnly = true)
     public double getLiquorCtrByLiquorId(final Long liquorId) {
-        return liquorCtrRepository.findByLiquorId(liquorId)
-            .orElseThrow(() -> new SoolSoolException(LiquorCtrErrorCode.NOT_LIQUOR_CTR_FOUND))
-            .getCtr();
+        return liquorCtrRedisRepository.getCtr(liquorId);
+    }
+
+    @Transactional
+    public void writeBackLiquorCtr(
+        final Long liquorId,
+        final LiquorCtrImpression impression,
+        final LiquorCtrClick click
+    ) {
+        final RLock rLock = redissonClient.getLock(LockType.LIQUOR_CTR.getPrefix() + liquorId);
+
+        try {
+            rLock.tryLock(LOCK_WAIT_TIME, LOCK_LEASE_TIME, TimeUnit.SECONDS);
+
+            final LiquorCtr liquorCtr = liquorCtrRepository.findByLiquorId(liquorId)
+                .orElseThrow(() -> new SoolSoolException(LiquorErrorCode.NOT_LIQUOR_CTR_FOUND));
+
+            liquorCtr.saveImpression(impression);
+            liquorCtr.saveClick(click);
+
+            liquorCtrRedisRepository.synchronizedWithDatabase(liquorId, impression, click);
+        } catch (final InterruptedException e) {
+            log.error("Redis to MySQL, LiquorCtr 갱신에 실패했습니다. | liquorId : {}", liquorId);
+
+            Thread.currentThread().interrupt();
+
+            throw new SoolSoolException(LiquorErrorCode.INTERRUPTED_THREAD);
+        } finally {
+            rLock.unlock();
+        }
     }
 }

--- a/src/test/java/com/woowacamp/soolsool/acceptance/LiquorCtrAcceptanceTest.java
+++ b/src/test/java/com/woowacamp/soolsool/acceptance/LiquorCtrAcceptanceTest.java
@@ -7,15 +7,23 @@ import com.woowacamp.soolsool.acceptance.fixture.RestAuthFixture;
 import com.woowacamp.soolsool.acceptance.fixture.RestLiquorFixture;
 import com.woowacamp.soolsool.acceptance.fixture.RestMemberFixture;
 import com.woowacamp.soolsool.core.liquor.dto.response.LiquorCtrDetailResponse;
+import com.woowacamp.soolsool.core.liquor.infra.RedisLiquorCtr;
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.redisson.api.RedissonClient;
+import org.springframework.beans.factory.annotation.Autowired;
 
 @DisplayName("인수 테스트: /liquor-ctr")
 class LiquorCtrAcceptanceTest extends AcceptanceTest {
 
+    private static final String LIQUOR_CTR_KEY = "LIQUOR_CTR";
+
     Long 새로;
+
+    @Autowired
+    RedissonClient redissonClient;
 
     @BeforeEach
     void setUpData() {
@@ -23,6 +31,9 @@ class LiquorCtrAcceptanceTest extends AcceptanceTest {
 
         String 최민족_토큰 = RestAuthFixture.로그인_최민족_판매자();
         새로 = RestLiquorFixture.술_등록_새로_판매중(최민족_토큰);
+
+        redissonClient.getMapCache(LIQUOR_CTR_KEY)
+            .put(새로, new RedisLiquorCtr(0L, 0L));
     }
 
     @Test

--- a/src/test/java/com/woowacamp/soolsool/core/cart/service/CartServiceIntegrationTest.java
+++ b/src/test/java/com/woowacamp/soolsool/core/cart/service/CartServiceIntegrationTest.java
@@ -13,6 +13,7 @@ import com.woowacamp.soolsool.core.liquor.repository.LiquorBrewCache;
 import com.woowacamp.soolsool.core.liquor.repository.LiquorQueryDslRepository;
 import com.woowacamp.soolsool.core.liquor.repository.LiquorRegionCache;
 import com.woowacamp.soolsool.core.liquor.repository.LiquorStatusCache;
+import com.woowacamp.soolsool.core.liquor.repository.redisson.LiquorCtrRedisRepository;
 import com.woowacamp.soolsool.core.liquor.service.LiquorService;
 import com.woowacamp.soolsool.global.config.QuerydslConfig;
 import com.woowacamp.soolsool.global.config.RedissonConfig;
@@ -31,7 +32,7 @@ import org.springframework.test.context.jdbc.Sql;
     LiquorStatusCache.class, LiquorRegionCache.class, LiquorQueryDslRepository.class,
     LiquorStatusCache.class, LiquorRegionCache.class,
     QuerydslConfig.class,
-    RedissonConfig.class})
+    RedissonConfig.class, LiquorCtrRedisRepository.class})
 @DisplayName("통합 테스트: CartItemService")
 class CartServiceIntegrationTest {
 

--- a/src/test/java/com/woowacamp/soolsool/core/liquor/repository/redisson/LiquorCtrRedisRepositoryTest.java
+++ b/src/test/java/com/woowacamp/soolsool/core/liquor/repository/redisson/LiquorCtrRedisRepositoryTest.java
@@ -1,0 +1,102 @@
+package com.woowacamp.soolsool.core.liquor.repository.redisson;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.woowacamp.soolsool.core.liquor.domain.vo.LiquorCtrClick;
+import com.woowacamp.soolsool.core.liquor.domain.vo.LiquorCtrImpression;
+import com.woowacamp.soolsool.global.config.RedissonConfig;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+@DataJpaTest
+@Import({LiquorCtrRedisRepository.class, RedissonConfig.class})
+@DisplayName("통합 테스트 : LiquorCtrRedisRepository")
+class LiquorCtrRedisRepositoryTest {
+
+    @Autowired
+    LiquorCtrRedisRepository liquorCtrRedisRepository;
+
+    @Test
+    @DisplayName("노출수를 1 증가시킨다.")
+    void updateImpression() {
+        // given
+        liquorCtrRedisRepository.save(1L, new LiquorCtrImpression(0L), new LiquorCtrClick(0L));
+
+        // when
+        liquorCtrRedisRepository.increaseImpression(1L);
+
+        // then
+        LiquorCtrImpression click = liquorCtrRedisRepository.findImpressionByLiquorId(1L);
+        assertThat(click.getImpression()).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("다중 쓰레드를 사용해 노출수를 50 증가시킨다.")
+    void updateImpressionByMultiThread() throws InterruptedException {
+        // given
+        long liquorId = 1L;
+        liquorCtrRedisRepository.save(liquorId, new LiquorCtrImpression(0L), new LiquorCtrClick(0L));
+
+        int threadCount = 50;
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        // when
+        for (int i = 0; i < threadCount; i++) {
+            executor.submit(() -> {
+                liquorCtrRedisRepository.increaseImpression(liquorId);
+                latch.countDown();
+            });
+        }
+        latch.await();
+
+        // then
+        LiquorCtrImpression click = liquorCtrRedisRepository.findImpressionByLiquorId(liquorId);
+        assertThat(click.getImpression()).isEqualTo(threadCount);
+    }
+
+    @Test
+    @DisplayName("클릭수를 1 증가시킨다.")
+    void updateClick() {
+        // given
+        liquorCtrRedisRepository.save(1L, new LiquorCtrImpression(0L), new LiquorCtrClick(0L));
+
+        // when
+        liquorCtrRedisRepository.increaseClick(1L);
+
+        // then
+        LiquorCtrClick click = liquorCtrRedisRepository.findClickByLiquorId(1L);
+        assertThat(click.getClick()).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("다중 쓰레드를 사용해 클릭수를 50 증가시킨다.")
+    void updateClickByMultiThread() throws InterruptedException {
+        // given
+        long liquorId = 1L;
+        liquorCtrRedisRepository.save(liquorId, new LiquorCtrImpression(0L), new LiquorCtrClick(0L));
+
+        int threadCount = 50;
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        // when
+        for (int i = 0; i < threadCount; i++) {
+            executor.submit(() -> {
+                liquorCtrRedisRepository.increaseClick(liquorId);
+                latch.countDown();
+            });
+        }
+        latch.await();
+
+        // then
+        LiquorCtrClick click = liquorCtrRedisRepository.findClickByLiquorId(liquorId);
+        assertThat(click.getClick()).isEqualTo(threadCount);
+    }
+}

--- a/src/test/java/com/woowacamp/soolsool/core/liquor/repository/redisson/LiquorCtrRedisRepositoryTest.java
+++ b/src/test/java/com/woowacamp/soolsool/core/liquor/repository/redisson/LiquorCtrRedisRepositoryTest.java
@@ -4,12 +4,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.woowacamp.soolsool.core.liquor.domain.vo.LiquorCtrClick;
 import com.woowacamp.soolsool.core.liquor.domain.vo.LiquorCtrImpression;
+import com.woowacamp.soolsool.core.liquor.infra.RedisLiquorCtr;
 import com.woowacamp.soolsool.global.config.RedissonConfig;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.redisson.api.RMapCache;
+import org.redisson.api.RedissonClient;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
@@ -19,14 +23,25 @@ import org.springframework.context.annotation.Import;
 @DisplayName("통합 테스트 : LiquorCtrRedisRepository")
 class LiquorCtrRedisRepositoryTest {
 
+    private static final String LIQUOR_CTR_KEY = "LIQUOR_CTR";
+
     @Autowired
     LiquorCtrRedisRepository liquorCtrRedisRepository;
+
+    @Autowired
+    RedissonClient redissonClient;
+
+    @BeforeEach
+    void setUpLiquorCtr() {
+        RMapCache<Long, RedisLiquorCtr> mapCache = redissonClient.getMapCache(LIQUOR_CTR_KEY);
+
+        mapCache.clear();
+    }
 
     @Test
     @DisplayName("노출수를 1 증가시킨다.")
     void updateImpression() {
         // given
-        liquorCtrRedisRepository.save(1L, new LiquorCtrImpression(0L), new LiquorCtrClick(0L));
 
         // when
         liquorCtrRedisRepository.increaseImpression(1L);
@@ -37,11 +52,10 @@ class LiquorCtrRedisRepositoryTest {
     }
 
     @Test
-    @DisplayName("다중 쓰레드를 사용해 노출수를 50 증가시킨다.")
+    @DisplayName("멀티 쓰레드를 사용해 노출수를 50 증가시킨다.")
     void updateImpressionByMultiThread() throws InterruptedException {
         // given
         long liquorId = 1L;
-        liquorCtrRedisRepository.save(liquorId, new LiquorCtrImpression(0L), new LiquorCtrClick(0L));
 
         int threadCount = 50;
         ExecutorService executor = Executors.newFixedThreadPool(threadCount);
@@ -65,7 +79,6 @@ class LiquorCtrRedisRepositoryTest {
     @DisplayName("클릭수를 1 증가시킨다.")
     void updateClick() {
         // given
-        liquorCtrRedisRepository.save(1L, new LiquorCtrImpression(0L), new LiquorCtrClick(0L));
 
         // when
         liquorCtrRedisRepository.increaseClick(1L);
@@ -76,11 +89,10 @@ class LiquorCtrRedisRepositoryTest {
     }
 
     @Test
-    @DisplayName("다중 쓰레드를 사용해 클릭수를 50 증가시킨다.")
+    @DisplayName("멀티 쓰레드를 사용해 클릭수를 50 증가시킨다.")
     void updateClickByMultiThread() throws InterruptedException {
         // given
         long liquorId = 1L;
-        liquorCtrRedisRepository.save(liquorId, new LiquorCtrImpression(0L), new LiquorCtrClick(0L));
 
         int threadCount = 50;
         ExecutorService executor = Executors.newFixedThreadPool(threadCount);

--- a/src/test/java/com/woowacamp/soolsool/core/liquor/service/LiquorServiceIntegrationTest.java
+++ b/src/test/java/com/woowacamp/soolsool/core/liquor/service/LiquorServiceIntegrationTest.java
@@ -10,10 +10,14 @@ import com.woowacamp.soolsool.core.liquor.dto.LiquorDetailResponse;
 import com.woowacamp.soolsool.core.liquor.dto.LiquorModifyRequest;
 import com.woowacamp.soolsool.core.liquor.dto.LiquorSaveRequest;
 import com.woowacamp.soolsool.core.liquor.repository.LiquorBrewCache;
+import com.woowacamp.soolsool.core.liquor.repository.LiquorBrewRepository;
 import com.woowacamp.soolsool.core.liquor.repository.LiquorQueryDslRepository;
 import com.woowacamp.soolsool.core.liquor.repository.LiquorRegionCache;
+import com.woowacamp.soolsool.core.liquor.repository.LiquorRegionRepository;
 import com.woowacamp.soolsool.core.liquor.repository.LiquorRepository;
 import com.woowacamp.soolsool.core.liquor.repository.LiquorStatusCache;
+import com.woowacamp.soolsool.core.liquor.repository.LiquorStatusRepository;
+import com.woowacamp.soolsool.core.liquor.repository.redisson.LiquorCtrRedisRepository;
 import com.woowacamp.soolsool.core.receipt.repository.redisson.ReceiptRedisRepository;
 import com.woowacamp.soolsool.global.config.QuerydslConfig;
 import com.woowacamp.soolsool.global.config.RedissonConfig;
@@ -22,6 +26,7 @@ import java.time.LocalDateTime;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.redisson.api.RedissonClient;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
@@ -31,7 +36,7 @@ import org.springframework.test.context.jdbc.Sql;
 @Import({LiquorService.class, LiquorBrewCache.class, LiquorStatusCache.class,
     LiquorRegionCache.class, LiquorQueryDslRepository.class,
     QuerydslConfig.class,
-    RedissonConfig.class, ReceiptRedisRepository.class})
+    RedissonConfig.class, ReceiptRedisRepository.class, LiquorCtrRedisRepository.class})
 @DisplayName("통합 테스트: LiquorService")
 class LiquorServiceIntegrationTest {
 
@@ -41,6 +46,21 @@ class LiquorServiceIntegrationTest {
     @Autowired
     LiquorRepository liquorRepository;
 
+    @Autowired
+    LiquorBrewRepository liquorBrewRepository;
+
+    @Autowired
+    LiquorRegionRepository liquorRegionRepository;
+
+    @Autowired
+    LiquorStatusRepository liquorStatusRepository;
+
+    @Autowired
+    LiquorCtrRedisRepository liquorCtrRedisRepository;
+
+    @Autowired
+    RedissonClient redissonClient;
+
     @Test
     @Sql({
         "/member-type.sql", "/member.sql",
@@ -49,13 +69,12 @@ class LiquorServiceIntegrationTest {
         "/order-type.sql", "/order.sql"
     })
     @DisplayName("상품 상세 정보를 조회한다.")
-    void liquorDetail() throws Exception {
+    void liquorDetail() {
         /* given */
         Long 새로 = 1L;
 
         /* when */
         LiquorDetailResponse response = liquorService.liquorDetail(새로);
-
 
         /* then */
         assertAll(
@@ -122,6 +141,7 @@ class LiquorServiceIntegrationTest {
             100, 12.0, 300,
             LocalDateTime.now().plusYears(10L)
         );
+
         // when & then
         assertThatCode(() -> liquorService.modifyLiquor(liquorId, liquorModifyRequest))
             .isInstanceOf(SoolSoolException.class)

--- a/src/test/java/com/woowacamp/soolsool/core/receipt/service/ReceiptServiceIntegrationTest.java
+++ b/src/test/java/com/woowacamp/soolsool/core/receipt/service/ReceiptServiceIntegrationTest.java
@@ -13,6 +13,7 @@ import com.woowacamp.soolsool.core.liquor.repository.LiquorBrewCache;
 import com.woowacamp.soolsool.core.liquor.repository.LiquorQueryDslRepository;
 import com.woowacamp.soolsool.core.liquor.repository.LiquorRegionCache;
 import com.woowacamp.soolsool.core.liquor.repository.LiquorStatusCache;
+import com.woowacamp.soolsool.core.liquor.repository.redisson.LiquorCtrRedisRepository;
 import com.woowacamp.soolsool.core.liquor.service.LiquorService;
 import com.woowacamp.soolsool.core.receipt.dto.response.ReceiptDetailResponse;
 import com.woowacamp.soolsool.core.receipt.repository.ReceiptStatusCache;
@@ -32,7 +33,7 @@ import org.springframework.test.context.jdbc.Sql;
     ReceiptMapper.class, LiquorBrewCache.class, LiquorStatusCache.class,
     LiquorRegionCache.class, ReceiptStatusCache.class,
     LiquorQueryDslRepository.class, QuerydslConfig.class,
-    RedissonConfig.class, ReceiptRedisRepository.class})
+    RedissonConfig.class, ReceiptRedisRepository.class, LiquorCtrRedisRepository.class})
 @DisplayName("통합 테스트: ReceiptService")
 class ReceiptServiceIntegrationTest {
 


### PR DESCRIPTION
## ♻️ 변경 사항

### 조회 시 로직
1. 요청이 들어온다.
2. Redis에서 해당 상품의 CTR 데이터를 가져온다. (첫 실행 또는 만료로 인해 해당 데이터가 없을 경우 TTL 5분으로 새로 생성)
3. 클릭수(or 노출수)를 1 증가시킨 뒤 Redis에 저장된 값을 변경한다.

### 만료 시 로직
1. Redis의 데이터가 만료되어 `LiquorCtrExpiredEvent`를 publish 한다.
2. `LiquorCtrExpiredEventListener`가 해당 이벤트를 받아서 `liquorCtrService`의 `writeBackLiquorCtr()`를 호출한다.
3. `liquorCtrService`는 전달받은 이벤트에서 데이터를 꺼내 MySQL에 저장한다.
4. 아래의 로직을 거쳐 노출수와 클릭수를 Redis에 다시 반영한다.
    1. Redis에 CTR 데이터가 `없다면` 새로 생성한다. (이벤트 실행 직전에 조회 요청이 들어 와 데이터가 다시 생성됐을 수 있으므로)
    2. Redis로부터 CTR 데이터를 가져온다. (기존 데이터 or 방금 생성한 데이터)
    3. 가져온 데이터에 MySQL에 저장했던 데이터를 더한다. (Redis에 저장된 CTR이 항상 최신을 유지하도록)
    4. 더한 값으로 교체하여 Redis를 최신값으로 반영한다.

<br>

## 📌 참고 사항

<br>

## 🎸 기타

closes #153 
