### PR TITLE
feat: handler method logging AOP 추가

### DIFF
--- a/src/main/java/com/woowacamp/soolsool/core/cart/controller/CartController.java
+++ b/src/main/java/com/woowacamp/soolsool/core/cart/controller/CartController.java
@@ -10,10 +10,10 @@ import com.woowacamp.soolsool.core.cart.dto.request.CartItemModifyRequest;
 import com.woowacamp.soolsool.core.cart.dto.request.CartItemSaveRequest;
 import com.woowacamp.soolsool.core.cart.dto.response.CartItemResponse;
 import com.woowacamp.soolsool.core.cart.service.CartService;
+import com.woowacamp.soolsool.global.aop.RequestLogging;
 import com.woowacamp.soolsool.global.auth.dto.LoginUser;
 import com.woowacamp.soolsool.global.common.ApiResponse;
 import java.util.List;
-import javax.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -34,73 +34,56 @@ public class CartController {
 
     private final CartService cartService;
 
+    @RequestLogging
     @PostMapping
     public ResponseEntity<ApiResponse<Long>> addCartItem(
-        final HttpServletRequest httpServletRequest,
         @LoginUser final Long memberId,
         @RequestBody final CartItemSaveRequest cartItemSaveRequest
     ) {
-        log.info("{} {} | memberId : {} | request : {}",
-            httpServletRequest.getMethod(), httpServletRequest.getServletPath(),
-            memberId, cartItemSaveRequest);
-
         final Long cartItemId = cartService.addCartItem(memberId, cartItemSaveRequest);
 
         // TODO: DTO로 반환하기 "cartItemId": 1
         return ResponseEntity.ok(ApiResponse.of(CART_ITEM_ADD_SUCCESS, cartItemId));
     }
 
+    @RequestLogging
     @PatchMapping("/{cartItemId}")
     public ResponseEntity<ApiResponse<Void>> modifyCartItemQuantity(
-        final HttpServletRequest httpServletRequest,
         @LoginUser final Long memberId,
         @PathVariable final Long cartItemId,
         @RequestBody final CartItemModifyRequest cartItemModifyRequest
     ) {
-        log.info("{} {} | memberId : {} | request : {}",
-            httpServletRequest.getMethod(), httpServletRequest.getServletPath(),
-            memberId, cartItemModifyRequest);
-
         cartService.modifyCartItemQuantity(memberId, cartItemId, cartItemModifyRequest);
 
         return ResponseEntity.ok(ApiResponse.from(CART_ITEM_MODIFY_QUANTITY_SUCCESS));
     }
 
+    @RequestLogging
     @GetMapping
     public ResponseEntity<ApiResponse<List<CartItemResponse>>> cartItemList(
-        final HttpServletRequest httpServletRequest,
         @LoginUser final Long memberId
     ) {
-        log.info("{} {} | memberId : {}",
-            httpServletRequest.getMethod(), httpServletRequest.getServletPath(), memberId);
-
         final List<CartItemResponse> cartItemResponses = cartService.cartItemList(memberId);
 
         return ResponseEntity.ok(ApiResponse.of(CART_ITEM_LIST_FOUND, cartItemResponses));
     }
 
+    @RequestLogging
     @DeleteMapping("/{cartItemId}")
     public ResponseEntity<ApiResponse<Void>> removeCartItem(
-        final HttpServletRequest httpServletRequest,
         @LoginUser final Long memberId,
         @PathVariable final Long cartItemId
     ) {
-        log.info("{} {} | memberId : {}",
-            httpServletRequest.getMethod(), httpServletRequest.getServletPath(), memberId);
-
         cartService.removeCartItem(memberId, cartItemId);
 
         return ResponseEntity.ok(ApiResponse.from(CART_ITEM_DELETED));
     }
 
+    @RequestLogging
     @DeleteMapping
     public ResponseEntity<ApiResponse<Void>> removeCartItemList(
-        final HttpServletRequest httpServletRequest,
         @LoginUser final Long memberId
     ) {
-        log.info("{} {} | memberId : {}",
-            httpServletRequest.getMethod(), httpServletRequest.getServletPath(), memberId);
-
         cartService.removeCartItems(memberId);
 
         return ResponseEntity.ok(ApiResponse.from(CART_ITEM_LIST_DELETED));

--- a/src/main/java/com/woowacamp/soolsool/core/liquor/controller/LiquorController.java
+++ b/src/main/java/com/woowacamp/soolsool/core/liquor/controller/LiquorController.java
@@ -14,11 +14,11 @@ import com.woowacamp.soolsool.core.liquor.dto.LiquorModifyRequest;
 import com.woowacamp.soolsool.core.liquor.dto.LiquorSaveRequest;
 import com.woowacamp.soolsool.core.liquor.dto.PageLiquorResponse;
 import com.woowacamp.soolsool.core.liquor.service.LiquorService;
+import com.woowacamp.soolsool.global.aop.RequestLogging;
 import com.woowacamp.soolsool.global.auth.dto.NoAuth;
 import com.woowacamp.soolsool.global.auth.dto.Vendor;
 import com.woowacamp.soolsool.global.common.ApiResponse;
 import java.net.URI;
-import javax.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
@@ -46,14 +46,11 @@ public class LiquorController {
     private final LiquorService liquorService;
 
     @Vendor
+    @RequestLogging
     @PostMapping
     public ResponseEntity<ApiResponse<Long>> saveLiquor(
-        final HttpServletRequest httpServletRequest,
         @RequestBody final LiquorSaveRequest liquorSaveRequest
     ) {
-        log.info("{} {} | request : {}",
-            httpServletRequest.getMethod(), httpServletRequest.getServletPath(), liquorSaveRequest);
-
         final Long saveLiquorId = liquorService.saveLiquor(liquorSaveRequest);
 
         return ResponseEntity.created(URI.create("/liquors/" + saveLiquorId))
@@ -61,28 +58,22 @@ public class LiquorController {
     }
 
     @NoAuth
+    @RequestLogging
     @GetMapping("/{liquorId}")
     public ResponseEntity<ApiResponse<LiquorDetailResponse>> liquorDetail(
-        final HttpServletRequest httpServletRequest,
         @PathVariable final Long liquorId
     ) {
-        log.info("{} {}",
-            httpServletRequest.getMethod(), httpServletRequest.getServletPath());
-
         final LiquorDetailResponse response = liquorService.liquorDetail(liquorId);
 
         return ResponseEntity.ok(ApiResponse.of(LiquorResultCode.LIQUOR_DETAIL_FOUND, response));
     }
 
     @NoAuth
+    @RequestLogging
     @GetMapping("/first")
     public ResponseEntity<ApiResponse<PageLiquorResponse>> getLiquorFirstList(
-        final HttpServletRequest httpServletRequest,
         @PageableDefault final Pageable pageable
     ) {
-        log.info("{} {} |  Pageable : {}", httpServletRequest.getMethod(),
-            httpServletRequest.getServletPath(), pageable);
-
         final PageRequest sortPageable = PageRequest.of(
             pageable.getPageNumber(),
             pageable.getPageSize(),
@@ -95,9 +86,9 @@ public class LiquorController {
     }
 
     @NoAuth
+    @RequestLogging
     @GetMapping
     public ResponseEntity<ApiResponse<PageLiquorResponse>> liquorList(
-        final HttpServletRequest httpServletRequest,
         @RequestParam("brew") @Nullable final LiquorBrewType brew,
         @RequestParam("region") @Nullable final LiquorRegionType region,
         @RequestParam("status") @Nullable final LiquorStatusType status,
@@ -105,10 +96,6 @@ public class LiquorController {
         @RequestParam @Nullable final Long cursorId,
         @PageableDefault final Pageable pageable
     ) {
-        log.info("{} {} | brew : {} | region : {} | status : {} | brand : {} | Pageable : {}",
-            httpServletRequest.getMethod(), httpServletRequest.getServletPath(),
-            brew, region, status, brand, pageable);
-
         final PageRequest sortPageable = PageRequest.of(
             pageable.getPageNumber(),
             pageable.getPageSize(),
@@ -122,30 +109,23 @@ public class LiquorController {
     }
 
     @Vendor
+    @RequestLogging
     @PutMapping("/{liquorId}")
     public ResponseEntity<ApiResponse<Void>> modifyLiquor(
-        final HttpServletRequest httpServletRequest,
         @PathVariable final Long liquorId,
         @RequestBody final LiquorModifyRequest liquorModifyRequest
     ) {
-        log.info("{} {} | request : {}",
-            httpServletRequest.getMethod(), httpServletRequest.getServletPath(),
-            liquorModifyRequest);
-
         liquorService.modifyLiquor(liquorId, liquorModifyRequest);
 
         return ResponseEntity.ok(ApiResponse.from(LIQUOR_UPDATED));
     }
 
     @Vendor
+    @RequestLogging
     @DeleteMapping("/{liquorId}")
     public ResponseEntity<ApiResponse<Void>> deleteLiquor(
-        final HttpServletRequest httpServletRequest,
         @PathVariable final Long liquorId
     ) {
-        log.info("{} {}",
-            httpServletRequest.getMethod(), httpServletRequest.getServletPath());
-
         liquorService.deleteLiquor(liquorId);
 
         return ResponseEntity.ok().body(ApiResponse.from(LIQUOR_DELETED));

--- a/src/main/java/com/woowacamp/soolsool/core/liquor/controller/LiquorCtrController.java
+++ b/src/main/java/com/woowacamp/soolsool/core/liquor/controller/LiquorCtrController.java
@@ -3,6 +3,7 @@ package com.woowacamp.soolsool.core.liquor.controller;
 import com.woowacamp.soolsool.core.liquor.code.LiquorCtrResultCode;
 import com.woowacamp.soolsool.core.liquor.dto.response.LiquorCtrDetailResponse;
 import com.woowacamp.soolsool.core.liquor.service.LiquorCtrService;
+import com.woowacamp.soolsool.global.aop.RequestLogging;
 import com.woowacamp.soolsool.global.auth.dto.NoAuth;
 import com.woowacamp.soolsool.global.common.ApiResponse;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +21,7 @@ public class LiquorCtrController {
     private final LiquorCtrService liquorCtrService;
 
     @NoAuth
+    @RequestLogging
     @GetMapping
     public ResponseEntity<ApiResponse<LiquorCtrDetailResponse>> findLiquorCtr(
         @RequestParam final Long liquorId

--- a/src/main/java/com/woowacamp/soolsool/core/liquor/controller/LiquorStockController.java
+++ b/src/main/java/com/woowacamp/soolsool/core/liquor/controller/LiquorStockController.java
@@ -2,10 +2,10 @@ package com.woowacamp.soolsool.core.liquor.controller;
 
 import com.woowacamp.soolsool.core.liquor.dto.LiquorStockSaveRequest;
 import com.woowacamp.soolsool.core.liquor.service.LiquorStockService;
+import com.woowacamp.soolsool.global.aop.RequestLogging;
 import com.woowacamp.soolsool.global.auth.dto.Vendor;
 import com.woowacamp.soolsool.global.common.ApiResponse;
 import com.woowacamp.soolsool.global.common.LiquorResultCode;
-import javax.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -23,14 +23,11 @@ public class LiquorStockController {
     private final LiquorStockService liquorStockService;
 
     @Vendor
+    @RequestLogging
     @PutMapping
     public ResponseEntity<ApiResponse<Void>> saveLiquorStock(
-        final HttpServletRequest httpServletRequest,
         @RequestBody final LiquorStockSaveRequest request
     ) {
-        log.info("{} {} | request : {}",
-            httpServletRequest.getMethod(), httpServletRequest.getServletPath(), request);
-
         liquorStockService.saveLiquorStock(request);
 
         return ResponseEntity.ok(ApiResponse.from(LiquorResultCode.LIQUOR_STOCK_SAVED));

--- a/src/main/java/com/woowacamp/soolsool/core/member/controller/MemberController.java
+++ b/src/main/java/com/woowacamp/soolsool/core/member/controller/MemberController.java
@@ -6,10 +6,10 @@ import com.woowacamp.soolsool.core.member.dto.request.MemberMileageChargeRequest
 import com.woowacamp.soolsool.core.member.dto.request.MemberModifyRequest;
 import com.woowacamp.soolsool.core.member.dto.response.MemberDetailResponse;
 import com.woowacamp.soolsool.core.member.service.MemberService;
+import com.woowacamp.soolsool.global.aop.RequestLogging;
 import com.woowacamp.soolsool.global.auth.dto.LoginUser;
 import com.woowacamp.soolsool.global.auth.dto.NoAuth;
 import com.woowacamp.soolsool.global.common.ApiResponse;
-import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -32,74 +32,57 @@ public class MemberController {
     private final MemberService memberService;
 
     @NoAuth
+    @RequestLogging
     @PostMapping
     public ResponseEntity<ApiResponse<Void>> addMember(
-        final HttpServletRequest httpServletRequest,
         @RequestBody @Valid final MemberAddRequest memberAddRequest
     ) {
-        log.info("{} {} | request : {}",
-            httpServletRequest.getMethod(), httpServletRequest.getServletPath(), memberAddRequest);
-
         memberService.addMember(memberAddRequest);
 
         return ResponseEntity.status(HttpStatus.OK)
             .body(ApiResponse.from(MemberResultCode.MEMBER_CREATE_SUCCESS));
     }
 
+    @RequestLogging
     @GetMapping
     public ResponseEntity<ApiResponse<MemberDetailResponse>> findMemberDetails(
-        final HttpServletRequest httpServletRequest,
         @LoginUser final Long memberId
     ) {
-        log.info("{} {} | memberId : {}",
-            httpServletRequest.getMethod(), httpServletRequest.getServletPath(), memberId);
-
         final MemberDetailResponse memberDetailResponse = memberService.findMember(memberId);
 
         return ResponseEntity.status(HttpStatus.OK)
             .body(ApiResponse.of(MemberResultCode.MEMBER_FIND_SUCCESS, memberDetailResponse));
     }
 
+    @RequestLogging
     @PatchMapping
     public ResponseEntity<ApiResponse<Void>> modifyMember(
-        final HttpServletRequest httpServletRequest,
         @LoginUser final Long memberId,
         @RequestBody @Valid final MemberModifyRequest memberModifyRequest
     ) {
-        log.info("{} {} | memberId : {} | request : {}",
-            httpServletRequest.getMethod(), httpServletRequest.getServletPath(),
-            memberId, memberModifyRequest);
-
         memberService.modifyMember(memberId, memberModifyRequest);
 
         return ResponseEntity.status(HttpStatus.OK)
             .body(ApiResponse.from(MemberResultCode.MEMBER_MODIFY_SUCCESS));
     }
 
+    @RequestLogging
     @DeleteMapping
     public ResponseEntity<ApiResponse<Void>> removeMember(
-        final HttpServletRequest httpServletRequest,
         @LoginUser final Long memberId
     ) {
-        log.info("{} {} | memberId : {}",
-            httpServletRequest.getMethod(), httpServletRequest.getServletPath(), memberId);
-
         memberService.removeMember(memberId);
 
         return ResponseEntity.status(HttpStatus.NO_CONTENT)
             .body(ApiResponse.from(MemberResultCode.MEMBER_DELETE_SUCCESS));
     }
 
+    @RequestLogging
     @PatchMapping("/mileage")
     public ResponseEntity<ApiResponse<Void>> addMemberMileage(
-        final HttpServletRequest httpServletRequest,
         @LoginUser final Long memberId,
         @RequestBody @Valid final MemberMileageChargeRequest memberMileageChargeRequest
     ) {
-        log.info("{} {} | memberId : {} | request : {}",
-            httpServletRequest.getMethod(), httpServletRequest.getServletPath(),
-            memberId, memberMileageChargeRequest);
-
         memberService.addMemberMileage(memberId, memberMileageChargeRequest);
 
         return ResponseEntity.status(HttpStatus.OK)

--- a/src/main/java/com/woowacamp/soolsool/core/order/controller/OrderController.java
+++ b/src/main/java/com/woowacamp/soolsool/core/order/controller/OrderController.java
@@ -5,10 +5,10 @@ import com.woowacamp.soolsool.core.order.dto.response.OrderDetailResponse;
 import com.woowacamp.soolsool.core.order.dto.response.OrderRatioResponse;
 import com.woowacamp.soolsool.core.order.dto.response.PageOrderListResponse;
 import com.woowacamp.soolsool.core.order.service.OrderService;
+import com.woowacamp.soolsool.global.aop.RequestLogging;
 import com.woowacamp.soolsool.global.auth.dto.LoginUser;
 import com.woowacamp.soolsool.global.auth.dto.NoAuth;
 import com.woowacamp.soolsool.global.common.ApiResponse;
-import javax.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
@@ -29,59 +29,47 @@ public class OrderController {
 
     private final OrderService orderService;
 
+    @RequestLogging
     @GetMapping("/{orderId}")
     public ResponseEntity<ApiResponse<OrderDetailResponse>> orderDetail(
-        final HttpServletRequest httpServletRequest,
         @LoginUser final Long memberId,
         @PathVariable final Long orderId
     ) {
-        log.info("{} {} | memberId : {}",
-            httpServletRequest.getMethod(), httpServletRequest.getServletPath(), memberId);
-
         final OrderDetailResponse response = orderService.orderDetail(memberId, orderId);
 
         return ResponseEntity.ok(ApiResponse.of(OrderResultCode.ORDER_DETAIL_SUCCESS, response));
     }
 
+    @RequestLogging
     @GetMapping
     public ResponseEntity<ApiResponse<PageOrderListResponse>> orderList(
-        final HttpServletRequest httpServletRequest,
         @LoginUser final Long memberId,
         @PageableDefault final Pageable pageable,
         @RequestParam(required = false) final Long cursorId
     ) {
-        log.info("{} {} | memberId : {}",
-            httpServletRequest.getMethod(), httpServletRequest.getServletPath(), memberId);
-
         final PageOrderListResponse response = orderService.orderList(memberId, pageable, cursorId);
-        
+
         return ResponseEntity.ok(ApiResponse.of(OrderResultCode.ORDER_DETAIL_SUCCESS, response));
     }
 
     @NoAuth
+    @RequestLogging
     @GetMapping("/ratio")
     public ResponseEntity<ApiResponse<OrderRatioResponse>> getOrderRatioByLiquorId(
-        final HttpServletRequest httpServletRequest,
         @RequestParam final Long liquorId
     ) {
-        log.info("{} {} | liquorId : {}",
-            httpServletRequest.getMethod(), httpServletRequest.getServletPath(), liquorId);
-
         final Double ratio = orderService.getOrderRatioByLiquorId(liquorId);
 
         return ResponseEntity.ok(ApiResponse
             .of(OrderResultCode.ORDER_RATIO_SUCCESS, new OrderRatioResponse(ratio)));
     }
 
+    @RequestLogging
     @PatchMapping("/cancel/{orderId}")
     public ResponseEntity<ApiResponse<Void>> cancelOrder(
-        final HttpServletRequest httpServletRequest,
         @LoginUser final Long memberId,
         @PathVariable final Long orderId
     ) {
-        log.info("{} {} | memberId : {} | orderId : {}",
-            httpServletRequest.getMethod(), httpServletRequest.getServletPath(), memberId, orderId);
-
         orderService.cancelOrder(memberId, orderId);
 
         return ResponseEntity.ok(ApiResponse.from(OrderResultCode.ORDER_CANCEL_SUCCESS));

--- a/src/main/java/com/woowacamp/soolsool/core/payment/controller/PayController.java
+++ b/src/main/java/com/woowacamp/soolsool/core/payment/controller/PayController.java
@@ -9,10 +9,10 @@ import com.woowacamp.soolsool.core.payment.dto.request.PayOrderRequest;
 import com.woowacamp.soolsool.core.payment.dto.response.PayReadyResponse;
 import com.woowacamp.soolsool.core.payment.dto.response.PaySuccessResponse;
 import com.woowacamp.soolsool.core.payment.service.PayService;
+import com.woowacamp.soolsool.global.aop.RequestLogging;
 import com.woowacamp.soolsool.global.auth.dto.LoginUser;
 import com.woowacamp.soolsool.global.auth.dto.NoAuth;
 import com.woowacamp.soolsool.global.common.ApiResponse;
-import javax.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -32,31 +32,24 @@ public class PayController {
 
     private final PayService payService;
 
+    @RequestLogging
     @PostMapping("/ready")
     public ResponseEntity<ApiResponse<PayReadyResponse>> payReady(
-        final HttpServletRequest httpServletRequest,
         @LoginUser final Long memberId,
         @RequestBody final PayOrderRequest payOrderRequest
     ) {
-        log.info("{} {} | memberId : {} | request : {}",
-            httpServletRequest.getMethod(), httpServletRequest.getServletPath(),
-            memberId, payOrderRequest);
-
         return ResponseEntity.ok(
             ApiResponse.of(PAY_READY_SUCCESS, payService.ready(memberId, payOrderRequest)));
     }
 
     @NoAuth
+    @RequestLogging
     @GetMapping("/success/{receiptId}")
     public ResponseEntity<ApiResponse<PaySuccessResponse>> kakaoPaySuccess(
-        final HttpServletRequest httpServletRequest,
         @LoginUser final Long memberId,
         @PathVariable("receiptId") final Long receiptId,
         @RequestParam("pg_token") final String pgToken
     ) {
-        log.info("{} {} | memberId : {} | pg_token : {}",
-            httpServletRequest.getMethod(), httpServletRequest.getServletPath(), memberId, pgToken);
-
         final Order order = payService.approve(memberId, receiptId, pgToken);
 
         return ResponseEntity.ok(
@@ -64,30 +57,24 @@ public class PayController {
     }
 
     @NoAuth
+    @RequestLogging
     @GetMapping("/cancel/{receiptId}")
     public ResponseEntity<ApiResponse<Long>> kakaoPayCancel(
-        final HttpServletRequest httpServletRequest,
         @LoginUser final Long memberId,
         @PathVariable final Long receiptId
     ) {
-        log.info("{} {} | memberId : {}",
-            httpServletRequest.getMethod(), httpServletRequest.getServletPath(), memberId);
-
         payService.cancelReceipt(memberId, receiptId);
 
         return ResponseEntity.ok(ApiResponse.from(PAY_READY_CANCEL));
     }
 
     @NoAuth
+    @RequestLogging
     @GetMapping("/fail/{receiptId}")
     public ResponseEntity<ApiResponse<Long>> kakaoPayFail(
-        final HttpServletRequest httpServletRequest,
         @LoginUser final Long memberId,
         @PathVariable final Long receiptId
     ) {
-        log.info("{} {} | memberId : {}",
-            httpServletRequest.getMethod(), httpServletRequest.getServletPath(), memberId);
-
         payService.cancelReceipt(memberId, receiptId);
 
         return ResponseEntity.ok(ApiResponse.from(PAY_READY_FAIL));

--- a/src/main/java/com/woowacamp/soolsool/core/receipt/controller/ReceiptController.java
+++ b/src/main/java/com/woowacamp/soolsool/core/receipt/controller/ReceiptController.java
@@ -5,10 +5,10 @@ import static com.woowacamp.soolsool.core.receipt.code.ReceiptResultCode.RECEIPT
 
 import com.woowacamp.soolsool.core.receipt.dto.response.ReceiptDetailResponse;
 import com.woowacamp.soolsool.core.receipt.service.ReceiptService;
+import com.woowacamp.soolsool.global.aop.RequestLogging;
 import com.woowacamp.soolsool.global.auth.dto.LoginUser;
 import com.woowacamp.soolsool.global.common.ApiResponse;
 import java.net.URI;
-import javax.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -26,29 +26,23 @@ public class ReceiptController {
 
     private final ReceiptService receiptService;
 
+    @RequestLogging
     @PostMapping
     public ResponseEntity<ApiResponse<Long>> addReceipt(
-        final HttpServletRequest httpServletRequest,
         @LoginUser final Long memberId
     ) {
-        log.info("{} {} | memberId : {}",
-            httpServletRequest.getMethod(), httpServletRequest.getServletPath(), memberId);
-
         final Long receiptId = receiptService.addReceipt(memberId);
 
         return ResponseEntity.created(URI.create("/receipts/" + receiptId))
             .body(ApiResponse.of(RECEIPT_ADD_SUCCESS, receiptId));
     }
 
+    @RequestLogging
     @GetMapping("/{receiptId}")
     public ResponseEntity<ApiResponse<ReceiptDetailResponse>> receiptDetails(
-        final HttpServletRequest httpServletRequest,
         @LoginUser final Long memberId,
         @PathVariable final Long receiptId
     ) {
-        log.info("{} {} | memberId : {}",
-            httpServletRequest.getMethod(), httpServletRequest.getServletPath(), memberId);
-
         final ReceiptDetailResponse receipt = receiptService.findReceipt(memberId, receiptId);
 
         return ResponseEntity.ok(ApiResponse.of(RECEIPT_FOUND, receipt));

--- a/src/main/java/com/woowacamp/soolsool/core/statistics/controller/StatisticsController.java
+++ b/src/main/java/com/woowacamp/soolsool/core/statistics/controller/StatisticsController.java
@@ -1,6 +1,7 @@
 package com.woowacamp.soolsool.core.statistics.controller;
 
 import com.woowacamp.soolsool.core.statistics.service.StatisticsService;
+import com.woowacamp.soolsool.global.aop.RequestLogging;
 import com.woowacamp.soolsool.global.auth.dto.NoAuth;
 import com.woowacamp.soolsool.global.common.ApiResponse;
 import lombok.RequiredArgsConstructor;
@@ -20,11 +21,10 @@ public class StatisticsController {
     private final StatisticsService statisticsService;
 
     @NoAuth
-    @GetMapping()
+    @RequestLogging
+    @GetMapping
     @Scheduled(cron = "0 0 0 * * *")
     public ResponseEntity<ApiResponse<Void>> updateStatisticsSales() {
-        log.info("/statistics | 자동 통계 집계 쿼리 실행");
-
         statisticsService.updateStatistics();
 
         return ResponseEntity.ok().build();

--- a/src/main/java/com/woowacamp/soolsool/global/aop/RequestLogging.java
+++ b/src/main/java/com/woowacamp/soolsool/global/aop/RequestLogging.java
@@ -1,0 +1,12 @@
+package com.woowacamp.soolsool.global.aop;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RequestLogging {
+
+}

--- a/src/main/java/com/woowacamp/soolsool/global/aop/RequestLoggingAspect.java
+++ b/src/main/java/com/woowacamp/soolsool/global/aop/RequestLoggingAspect.java
@@ -1,0 +1,57 @@
+package com.woowacamp.soolsool.global.aop;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import javax.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@Slf4j
+@Aspect
+@Component
+public class RequestLoggingAspect {
+
+    @Around("@annotation(com.woowacamp.soolsool.global.aop.RequestLogging)")
+    public Object logMethod2(ProceedingJoinPoint proceedingJoinPoint) throws Throwable {
+        final ServletRequestAttributes attributes = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+        if (Objects.isNull(attributes)) {
+            return proceedingJoinPoint.proceed();
+        }
+
+        final HttpServletRequest request = attributes.getRequest();
+        final Map<String, String[]> params = request.getParameterMap();
+
+        log.info("[REQUEST HANDLE] {} => {} {}{}, body: {}",
+            request.getRemoteHost(),
+            request.getMethod(), request.getRequestURI(), mapToFormatted(params),
+            extractBody(proceedingJoinPoint.getArgs())
+        );
+
+        return proceedingJoinPoint.proceed();
+    }
+
+    private String mapToFormatted(final Map<String, String[]> params) {
+        final String queryParams = params.entrySet().stream()
+            .map(entry -> String.join(entry.getKey() + "=", entry.getValue()))
+            .collect(Collectors.joining("&"));
+
+        if (StringUtils.hasText(queryParams)) {
+            return "?" + queryParams;
+        }
+
+        return queryParams;
+    }
+
+    private String extractBody(final Object[] args) {
+        return String.join(",", Arrays.toString(args));
+    }
+}
+

--- a/src/main/java/com/woowacamp/soolsool/global/aop/RequestLoggingAspect.java
+++ b/src/main/java/com/woowacamp/soolsool/global/aop/RequestLoggingAspect.java
@@ -21,7 +21,7 @@ import org.springframework.web.context.request.ServletRequestAttributes;
 public class RequestLoggingAspect {
 
     @Around("@annotation(com.woowacamp.soolsool.global.aop.RequestLogging)")
-    public Object logMethod2(ProceedingJoinPoint proceedingJoinPoint) throws Throwable {
+    public Object logRequest(ProceedingJoinPoint proceedingJoinPoint) throws Throwable {
         final ServletRequestAttributes attributes = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
         if (Objects.isNull(attributes)) {
             return proceedingJoinPoint.proceed();

--- a/src/main/java/com/woowacamp/soolsool/global/aop/RequestLoggingAspect.java
+++ b/src/main/java/com/woowacamp/soolsool/global/aop/RequestLoggingAspect.java
@@ -2,6 +2,7 @@ package com.woowacamp.soolsool.global.aop;
 
 import java.util.Arrays;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import javax.servlet.http.HttpServletRequest;
@@ -39,19 +40,24 @@ public class RequestLoggingAspect {
     }
 
     private String mapToFormatted(final Map<String, String[]> params) {
-        final String queryParams = params.entrySet().stream()
-            .map(entry -> String.join(entry.getKey() + "=", entry.getValue()))
+        final String formattedParams = params.entrySet().stream()
+            .map(this::formatParam)
             .collect(Collectors.joining("&"));
 
-        if (StringUtils.hasText(queryParams)) {
-            return "?" + queryParams;
+        if (StringUtils.hasText(formattedParams)) {
+            return "?" + formattedParams;
         }
 
-        return queryParams;
+        return formattedParams;
     }
 
     private String extractBody(final Object[] args) {
         return String.join(",", Arrays.toString(args));
     }
-}
 
+    private String formatParam(final Entry<String, String[]> entry) {
+        return Arrays.stream(entry.getValue())
+            .map(value -> entry.getKey() + "=" + value)
+            .collect(Collectors.joining("&"));
+    }
+}


### PR DESCRIPTION
## ♻️ 변경 사항

* AOP를 이용하여 handler method에 존재하는 logging 코드를 제거하고 불필요한 매개변수를 줄임


<br>

## 📌 참고 사항

### `@Scheduled`에 존재하는 `@GetMapping`과 반환값

@jjungsk StatisticsController에서 `@Scheduled` 메서드가 반환값이 있어서 경고가 뜨고 있어요.

`@Scheduled(cron = "0 0 0 * * *")`로 되어있으면 매 자정마다 실행하는 것 아닌가요? 별도의 GetMapping으로 endpoint를 추가하고 값을 반환하는 이유가 궁금해요.

### Interceptor로도 비슷하게 구현할 수 있었다.

Interceptor로도 구현할 수 있었는데 body 정보를 가져오는 과정에서 까다로워 AOP로 변경하였습니다. 

`HttpServletRequest`에서 body 정보를 읽기 위해선 `HttpServletRequest.getReader()`를 통해 가져온 후 `BufferedReader`를 모두 읽어 String을 생성해야합니다.

여기까진 괜찮은데 이후에 cursor가 끝으로 이동한 Reader를 Controller에서 다시 읽게되고 이때 아래와 같은 예외가 발생합니다.

> java.lang.IllegalStateException: getReader() has already been called for this request


이를 처리하는 과정이 꽤나 까다로워 이미 매개변수로 바인딩된 Object를 가져올 수 있는 AOP를 선택하였습니다.

또, Interceptor의 경우 json 파일이 길어질 경우 출력할 로그의 양도 증가하는 반면 AOP의 경우 매개 변수의 toString()을 어떻게 재정의 하나에 따라 출력할 로그의 양을 선택적으로 조절할 수 있다는 장점이 있습니다.


<br>

## 🎸 기타

close #139 

