### PR TITLE
test: Redis 테스트 환경을 Testcontainers 기반으로 변경

### DIFF
--- a/.github/workflows/check-code-status.yml
+++ b/.github/workflows/check-code-status.yml
@@ -9,10 +9,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - uses: shogo82148/actions-setup-redis@v1
-        with:
-          redis-version: '6.0'
-
       - name: Set environment variables to runner
         run: |
           echo "SOOLSOOL_JWT_SECRET=${{ secrets.SOOLSOOL_JWT_SECRET }}" >> $GITHUB_ENV

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf' // TODO: 삭제
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-cache'
@@ -45,6 +45,7 @@ dependencies {
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'io.rest-assured:rest-assured:4.4.0'
+    testImplementation 'org.testcontainers:testcontainers:1.19.0'
 
     // querydsl
     implementation "com.querydsl:querydsl-jpa"

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,6 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf' // TODO: 삭제
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-cache'

--- a/src/test/java/com/woowacamp/soolsool/acceptance/AcceptanceTest.java
+++ b/src/test/java/com/woowacamp/soolsool/acceptance/AcceptanceTest.java
@@ -1,10 +1,12 @@
 package com.woowacamp.soolsool.acceptance;
 
+import com.woowacamp.soolsool.config.RedisTestConfig;
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.jdbc.Sql;
@@ -12,6 +14,7 @@ import org.springframework.test.context.jdbc.Sql;
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
 @Sql({"/liquor-type.sql", "/member-type.sql", "/order-type.sql", "/receipt-type.sql"})
+@Import(RedisTestConfig.class)
 public abstract class AcceptanceTest {
 
     static final String BEARER = "Bearer ";

--- a/src/test/java/com/woowacamp/soolsool/config/RedisTestConfig.java
+++ b/src/test/java/com/woowacamp/soolsool/config/RedisTestConfig.java
@@ -1,0 +1,48 @@
+package com.woowacamp.soolsool.config;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.DockerImageName;
+
+@TestConfiguration
+public class RedisTestConfig {
+
+    static {
+        final GenericContainer<?> REDIS_CONTAINER =
+            new GenericContainer<>(DockerImageName.parse("redis:latest"))
+                .withExposedPorts(6379);
+        REDIS_CONTAINER.start();
+
+        System.setProperty("spring.redis.host", REDIS_CONTAINER.getHost());
+        System.setProperty("spring.redis.port",
+            String.valueOf(REDIS_CONTAINER.getFirstMappedPort()));
+    }
+
+    private final String host;
+    private final String port;
+
+    public RedisTestConfig(
+        @Value("${spring.redis.host}") final String host,
+        @Value("${spring.redis.port}") final String port
+    ) {
+        this.host = host;
+        this.port = port;
+    }
+
+    @Bean
+    public RedissonClient redissonClient() {
+        final Config config = new Config();
+        config
+            .setMinCleanUpDelay(0)
+            .setMaxCleanUpDelay(0)
+            .useSingleServer()
+            .setAddress("redis://" + host + ":" + port);
+
+        return Redisson.create(config);
+    }
+}

--- a/src/test/java/com/woowacamp/soolsool/core/cart/service/CartServiceIntegrationTest.java
+++ b/src/test/java/com/woowacamp/soolsool/core/cart/service/CartServiceIntegrationTest.java
@@ -7,6 +7,7 @@ import static com.woowacamp.soolsool.core.cart.code.CartErrorCode.NOT_FOUND_LIQU
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.woowacamp.soolsool.config.RedisTestConfig;
 import com.woowacamp.soolsool.core.cart.dto.request.CartItemModifyRequest;
 import com.woowacamp.soolsool.core.cart.dto.request.CartItemSaveRequest;
 import com.woowacamp.soolsool.core.liquor.repository.LiquorBrewCache;
@@ -32,7 +33,8 @@ import org.springframework.test.context.jdbc.Sql;
     LiquorStatusCache.class, LiquorRegionCache.class, LiquorQueryDslRepository.class,
     LiquorStatusCache.class, LiquorRegionCache.class,
     QuerydslConfig.class,
-    RedissonConfig.class, LiquorCtrRedisRepository.class})
+    RedissonConfig.class, LiquorCtrRedisRepository.class,
+    RedisTestConfig.class})
 @DisplayName("통합 테스트: CartItemService")
 class CartServiceIntegrationTest {
 

--- a/src/test/java/com/woowacamp/soolsool/core/cart/service/CartServiceIntegrationTest.java
+++ b/src/test/java/com/woowacamp/soolsool/core/cart/service/CartServiceIntegrationTest.java
@@ -17,7 +17,6 @@ import com.woowacamp.soolsool.core.liquor.repository.LiquorStatusCache;
 import com.woowacamp.soolsool.core.liquor.repository.redisson.LiquorCtrRedisRepository;
 import com.woowacamp.soolsool.core.liquor.service.LiquorService;
 import com.woowacamp.soolsool.global.config.QuerydslConfig;
-import com.woowacamp.soolsool.global.config.RedissonConfig;
 import com.woowacamp.soolsool.global.exception.SoolSoolException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -33,7 +32,7 @@ import org.springframework.test.context.jdbc.Sql;
     LiquorStatusCache.class, LiquorRegionCache.class, LiquorQueryDslRepository.class,
     LiquorStatusCache.class, LiquorRegionCache.class,
     QuerydslConfig.class,
-    RedissonConfig.class, LiquorCtrRedisRepository.class,
+    LiquorCtrRedisRepository.class,
     RedisTestConfig.class})
 @DisplayName("통합 테스트: CartItemService")
 class CartServiceIntegrationTest {


### PR DESCRIPTION
## ♻️ 변경 사항

* Redis 테스트 환경을 Testcontainers 라이브러리를 이용한 Docker 환경으로 변경하였습니다.
* Thymeleaf를 사용하지 않기 때문에 `build.gradle`에서 의존성을 제거하였습니다.
* CI 워크 플로우에서 로컬 Reids setup job을 제거하였습니다.

<br>

## 📌 참고 사항

이제부터 테스트 환경에서 Docker를 설치해야 테스트가 통과합니다.

<br>

## 🎸 기타

close #205
