### PR TITLE
refactor: LiquorCtr 반영 방식 리팩토링

### DIFF
--- a/src/main/java/com/woowacamp/soolsool/SoolsoolApplication.java
+++ b/src/main/java/com/woowacamp/soolsool/SoolsoolApplication.java
@@ -4,8 +4,10 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableAsync
 @EnableCaching
 @EnableScheduling
 @EnableJpaAuditing

--- a/src/main/java/com/woowacamp/soolsool/SoolsoolApplication.java
+++ b/src/main/java/com/woowacamp/soolsool/SoolsoolApplication.java
@@ -17,5 +17,4 @@ public class SoolsoolApplication {
     public static void main(String[] args) {
         SpringApplication.run(SoolsoolApplication.class, args);
     }
-
 }

--- a/src/main/java/com/woowacamp/soolsool/core/liquor/domain/LiquorCtr.java
+++ b/src/main/java/com/woowacamp/soolsool/core/liquor/domain/LiquorCtr.java
@@ -57,11 +57,6 @@ public class LiquorCtr extends BaseEntity {
         this.click = new LiquorCtrClick(click);
     }
 
-    public void overwrite(final LiquorCtr latest) {
-        this.impression = new LiquorCtrImpression(latest.getImpression());
-        this.click = new LiquorCtrClick(latest.getClick());
-    }
-
     public double getCtr() {
         if (impression.getImpression() == 0) {
             throw new SoolSoolException(LiquorCtrErrorCode.DIVIDE_BY_ZERO_IMPRESSION);

--- a/src/main/java/com/woowacamp/soolsool/core/liquor/domain/LiquorCtr.java
+++ b/src/main/java/com/woowacamp/soolsool/core/liquor/domain/LiquorCtr.java
@@ -9,6 +9,7 @@ import com.woowacamp.soolsool.core.liquor.domain.vo.LiquorCtrClick;
 import com.woowacamp.soolsool.core.liquor.domain.vo.LiquorCtrImpression;
 import com.woowacamp.soolsool.global.common.BaseEntity;
 import com.woowacamp.soolsool.global.exception.SoolSoolException;
+import java.util.Objects;
 import javax.persistence.Column;
 import javax.persistence.Convert;
 import javax.persistence.Entity;
@@ -44,15 +45,15 @@ public class LiquorCtr extends BaseEntity {
     private LiquorCtrClick click;
 
     @Builder
-    public LiquorCtr(@NonNull final Long liquorId) {
+    public LiquorCtr(@NonNull final Long liquorId, final Long impression, final Long click) {
         this.liquorId = liquorId;
-        this.impression = new LiquorCtrImpression(0L);
-        this.click = new LiquorCtrClick(0L);
+        this.impression = new LiquorCtrImpression(Objects.isNull(impression) ? 0L : impression);
+        this.click = new LiquorCtrClick(Objects.isNull(click) ? 0L : click);
     }
 
-    public void updateCtr(final LiquorCtrImpression impression, final LiquorCtrClick click) {
-        this.impression = impression;
-        this.click = click;
+    public void overwrite(final LiquorCtr latest) {
+        this.impression = new LiquorCtrImpression(latest.getImpression());
+        this.click = new LiquorCtrClick(latest.getClick());
     }
 
     public double getCtr() {

--- a/src/main/java/com/woowacamp/soolsool/core/liquor/domain/LiquorCtr.java
+++ b/src/main/java/com/woowacamp/soolsool/core/liquor/domain/LiquorCtr.java
@@ -17,6 +17,7 @@ import javax.persistence.Id;
 import javax.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 
@@ -27,9 +28,11 @@ public class LiquorCtr extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = IDENTITY)
+    @Getter
     private Long id;
 
     @Column(name = "liquor_id", nullable = false)
+    @Getter
     private Long liquorId;
 
     @Column(name = "impression", nullable = false)
@@ -47,19 +50,8 @@ public class LiquorCtr extends BaseEntity {
         this.click = new LiquorCtrClick(0L);
     }
 
-    public void increaseImpressionOne() {
-        this.impression = impression.increaseOne();
-    }
-
-    public void increaseClickOne() {
-        this.click = click.increaseOne();
-    }
-
-    public void saveImpression(final LiquorCtrImpression impression) {
+    public void updateCtr(final LiquorCtrImpression impression, final LiquorCtrClick click) {
         this.impression = impression;
-    }
-
-    public void saveClick(final LiquorCtrClick click) {
         this.click = click;
     }
 
@@ -71,5 +63,13 @@ public class LiquorCtr extends BaseEntity {
         final double ratio = (double) click.getClick() / impression.getImpression();
 
         return Math.round(ratio * 100) / 100.0;
+    }
+
+    public Long getImpression() {
+        return impression.getImpression();
+    }
+
+    public Long getClick() {
+        return click.getClick();
     }
 }

--- a/src/main/java/com/woowacamp/soolsool/core/liquor/domain/LiquorCtr.java
+++ b/src/main/java/com/woowacamp/soolsool/core/liquor/domain/LiquorCtr.java
@@ -28,7 +28,6 @@ public class LiquorCtr extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = IDENTITY)
-    @Getter
     private Long id;
 
     @Column(name = "liquor_id", nullable = false)
@@ -48,7 +47,11 @@ public class LiquorCtr extends BaseEntity {
     }
 
     @Builder
-    public LiquorCtr(@NonNull final Long liquorId, final Long impression, final Long click) {
+    public LiquorCtr(
+        @NonNull final Long liquorId,
+        final Long impression,
+        final Long click
+    ) {
         this.liquorId = liquorId;
         this.impression = new LiquorCtrImpression(impression);
         this.click = new LiquorCtrClick(click);

--- a/src/main/java/com/woowacamp/soolsool/core/liquor/domain/LiquorCtr.java
+++ b/src/main/java/com/woowacamp/soolsool/core/liquor/domain/LiquorCtr.java
@@ -9,7 +9,6 @@ import com.woowacamp.soolsool.core.liquor.domain.vo.LiquorCtrClick;
 import com.woowacamp.soolsool.core.liquor.domain.vo.LiquorCtrImpression;
 import com.woowacamp.soolsool.global.common.BaseEntity;
 import com.woowacamp.soolsool.global.exception.SoolSoolException;
-import java.util.Objects;
 import javax.persistence.Column;
 import javax.persistence.Convert;
 import javax.persistence.Entity;
@@ -44,11 +43,15 @@ public class LiquorCtr extends BaseEntity {
     @Convert(converter = LiquorCtrClickConverter.class)
     private LiquorCtrClick click;
 
+    public LiquorCtr(@NonNull final Long liquorId) {
+        this(liquorId, 0L, 0L);
+    }
+
     @Builder
     public LiquorCtr(@NonNull final Long liquorId, final Long impression, final Long click) {
         this.liquorId = liquorId;
-        this.impression = new LiquorCtrImpression(Objects.isNull(impression) ? 0L : impression);
-        this.click = new LiquorCtrClick(Objects.isNull(click) ? 0L : click);
+        this.impression = new LiquorCtrImpression(impression);
+        this.click = new LiquorCtrClick(click);
     }
 
     public void overwrite(final LiquorCtr latest) {

--- a/src/main/java/com/woowacamp/soolsool/core/liquor/dto/LiquorDetailResponse.java
+++ b/src/main/java/com/woowacamp/soolsool/core/liquor/dto/LiquorDetailResponse.java
@@ -18,7 +18,7 @@ public class LiquorDetailResponse {
     private final Integer stock;
     private final Double alcohol;
     private final Integer volume;
-    private final List<LiquorElementResponse> relatedLiquors;
+    private final List<LiquorElementResponse> relatedLiquors; // TODO: 연관 상품 API 분리
 
     public static LiquorDetailResponse of(final Liquor liquor, final List<Liquor> relatedLiquors) {
         final List<LiquorElementResponse> relatedLiquorResponses = relatedLiquors.stream()

--- a/src/main/java/com/woowacamp/soolsool/core/liquor/event/LiquorCtrExpiredEvent.java
+++ b/src/main/java/com/woowacamp/soolsool/core/liquor/event/LiquorCtrExpiredEvent.java
@@ -1,7 +1,7 @@
 package com.woowacamp.soolsool.core.liquor.event;
 
-import com.woowacamp.soolsool.core.liquor.domain.vo.LiquorCtrClick;
-import com.woowacamp.soolsool.core.liquor.domain.vo.LiquorCtrImpression;
+import com.woowacamp.soolsool.core.liquor.domain.LiquorCtr;
+import com.woowacamp.soolsool.core.liquor.infra.RedisLiquorCtr;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -10,6 +10,9 @@ import lombok.RequiredArgsConstructor;
 public class LiquorCtrExpiredEvent {
 
     private final Long liquorId;
-    private final LiquorCtrImpression impression;
-    private final LiquorCtrClick click;
+    private final RedisLiquorCtr redisLiquorCtr;
+
+    public LiquorCtr getLiquorCtr() {
+        return redisLiquorCtr.toEntity(liquorId);
+    }
 }

--- a/src/main/java/com/woowacamp/soolsool/core/liquor/event/listener/LiquorCtrExpiredEventListener.java
+++ b/src/main/java/com/woowacamp/soolsool/core/liquor/event/listener/LiquorCtrExpiredEventListener.java
@@ -16,10 +16,6 @@ public class LiquorCtrExpiredEventListener {
     @Async
     @EventListener
     public void expiredListener(final LiquorCtrExpiredEvent event) {
-        liquorCtrService.writeBackCtr(
-            event.getLiquorId(),
-            event.getImpression(),
-            event.getClick()
-        );
+        liquorCtrService.writeBackCtr(event.getLiquorCtr());
     }
 }

--- a/src/main/java/com/woowacamp/soolsool/core/liquor/event/listener/LiquorCtrExpiredEventListener.java
+++ b/src/main/java/com/woowacamp/soolsool/core/liquor/event/listener/LiquorCtrExpiredEventListener.java
@@ -4,6 +4,7 @@ import com.woowacamp.soolsool.core.liquor.event.LiquorCtrExpiredEvent;
 import com.woowacamp.soolsool.core.liquor.service.LiquorCtrService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -12,9 +13,10 @@ public class LiquorCtrExpiredEventListener {
 
     private final LiquorCtrService liquorCtrService;
 
+    @Async
     @EventListener
     public void expiredListener(final LiquorCtrExpiredEvent event) {
-        liquorCtrService.writeBackLiquorCtr(
+        liquorCtrService.writeBackCtr(
             event.getLiquorId(),
             event.getImpression(),
             event.getClick()

--- a/src/main/java/com/woowacamp/soolsool/core/liquor/infra/RedisLiquorCtr.java
+++ b/src/main/java/com/woowacamp/soolsool/core/liquor/infra/RedisLiquorCtr.java
@@ -1,9 +1,8 @@
 package com.woowacamp.soolsool.core.liquor.infra;
 
-import lombok.Getter;
+import com.woowacamp.soolsool.core.liquor.domain.LiquorCtr;
 import lombok.RequiredArgsConstructor;
 
-@Getter
 @RequiredArgsConstructor
 public class RedisLiquorCtr {
 
@@ -18,7 +17,11 @@ public class RedisLiquorCtr {
         return new RedisLiquorCtr(impression, click + 1);
     }
 
-    public RedisLiquorCtr synchronizedWithDatabase(final Long impression, final Long click) {
-        return new RedisLiquorCtr(this.impression + impression, this.click + click);
+    public LiquorCtr toEntity(final Long liquorId) {
+        return LiquorCtr.builder()
+            .liquorId(liquorId)
+            .impression(impression)
+            .click(click)
+            .build();
     }
 }

--- a/src/main/java/com/woowacamp/soolsool/core/liquor/repository/LiquorCtrRepository.java
+++ b/src/main/java/com/woowacamp/soolsool/core/liquor/repository/LiquorCtrRepository.java
@@ -4,6 +4,9 @@ import com.woowacamp.soolsool.core.liquor.domain.LiquorCtr;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -12,4 +15,15 @@ public interface LiquorCtrRepository extends JpaRepository<LiquorCtr, Long> {
     Optional<LiquorCtr> findByLiquorId(final Long liquorId);
 
     List<LiquorCtr> findAllByLiquorIdIn(final List<Long> liquorIds);
+
+    @Modifying
+    @Query(value = "update liquor_ctrs lc"
+        + " set lc.impression = :impression, lc.click = :click"
+        + " where lc.liquor_id = :liquorId",
+        nativeQuery = true)
+    void updateLiquorCtr(
+        @Param("impression") final Long impression,
+        @Param("click") final Long click,
+        @Param("liquorId") final Long liquorId
+    );
 }

--- a/src/main/java/com/woowacamp/soolsool/core/liquor/repository/redisson/LiquorCtrRedisRepository.java
+++ b/src/main/java/com/woowacamp/soolsool/core/liquor/repository/redisson/LiquorCtrRedisRepository.java
@@ -32,6 +32,7 @@ public class LiquorCtrRedisRepository {
 
     private final RedissonClient redissonClient;
 
+    // TODO: RedisLiquorCtr vs LiquorCtr
     public LiquorCtrRedisRepository(
         final LiquorCtrRepository liquorCtrRepository,
         final RedissonClient redissonClient,
@@ -72,25 +73,7 @@ public class LiquorCtrRedisRepository {
             throw new SoolSoolException(LiquorCtrErrorCode.DIVIDE_BY_ZERO_IMPRESSION);
         }
     }
-
-    public LiquorCtrImpression getImpressionByLiquorId(final Long liquorId) {
-        final RMapCache<Long, RedisLiquorCtr> liquorCtrs =
-            redissonClient.getMapCache(LIQUOR_CTR_KEY);
-
-        initLiquorCtrIfAbsent(liquorCtrs, liquorId);
-
-        return new LiquorCtrImpression(liquorCtrs.get(liquorId).getImpression());
-    }
-
-    public LiquorCtrClick getClickByLiquorId(final Long liquorId) {
-        final RMapCache<Long, RedisLiquorCtr> liquorCtrs =
-            redissonClient.getMapCache(LIQUOR_CTR_KEY);
-
-        initLiquorCtrIfAbsent(liquorCtrs, liquorId);
-
-        return new LiquorCtrClick(liquorCtrs.get(liquorId).getClick());
-    }
-
+    
     public void increaseImpression(final Long liquorId) {
         final RLock rLock = redissonClient.getLock(LockType.LIQUOR_CTR.getPrefix() + liquorId);
 

--- a/src/main/java/com/woowacamp/soolsool/core/liquor/service/LiquorCtrService.java
+++ b/src/main/java/com/woowacamp/soolsool/core/liquor/service/LiquorCtrService.java
@@ -1,18 +1,13 @@
 package com.woowacamp.soolsool.core.liquor.service;
 
-import com.woowacamp.soolsool.core.liquor.code.LiquorErrorCode;
-import com.woowacamp.soolsool.core.liquor.domain.LiquorCtr;
+import com.woowacamp.soolsool.core.liquor.code.LiquorCtrErrorCode;
 import com.woowacamp.soolsool.core.liquor.domain.vo.LiquorCtrClick;
 import com.woowacamp.soolsool.core.liquor.domain.vo.LiquorCtrImpression;
 import com.woowacamp.soolsool.core.liquor.repository.LiquorCtrRepository;
 import com.woowacamp.soolsool.core.liquor.repository.redisson.LiquorCtrRedisRepository;
 import com.woowacamp.soolsool.global.exception.SoolSoolException;
-import com.woowacamp.soolsool.global.infra.LockType;
-import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.redisson.api.RLock;
-import org.redisson.api.RedissonClient;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,14 +16,9 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class LiquorCtrService {
 
-    private static final long LOCK_WAIT_TIME = 3L;
-    private static final long LOCK_LEASE_TIME = 3L;
-
     private final LiquorCtrRepository liquorCtrRepository;
 
     private final LiquorCtrRedisRepository liquorCtrRedisRepository;
-
-    private final RedissonClient redissonClient;
 
     @Transactional(readOnly = true)
     public double getLiquorCtrByLiquorId(final Long liquorId) {
@@ -36,31 +26,13 @@ public class LiquorCtrService {
     }
 
     @Transactional
-    public void writeBackLiquorCtr(
+    public void writeBackCtr(
         final Long liquorId,
         final LiquorCtrImpression impression,
         final LiquorCtrClick click
     ) {
-        final RLock rLock = redissonClient.getLock(LockType.LIQUOR_CTR.getPrefix() + liquorId);
-
-        try {
-            rLock.tryLock(LOCK_WAIT_TIME, LOCK_LEASE_TIME, TimeUnit.SECONDS);
-
-            final LiquorCtr liquorCtr = liquorCtrRepository.findByLiquorId(liquorId)
-                .orElseThrow(() -> new SoolSoolException(LiquorErrorCode.NOT_LIQUOR_CTR_FOUND));
-
-            liquorCtr.saveImpression(impression);
-            liquorCtr.saveClick(click);
-
-            liquorCtrRedisRepository.synchronizedWithDatabase(liquorId, impression, click);
-        } catch (final InterruptedException e) {
-            log.error("Redis to MySQL, LiquorCtr 갱신에 실패했습니다. | liquorId : {}", liquorId);
-
-            Thread.currentThread().interrupt();
-
-            throw new SoolSoolException(LiquorErrorCode.INTERRUPTED_THREAD);
-        } finally {
-            rLock.unlock();
-        }
+        liquorCtrRepository.findByLiquorId(liquorId)
+            .orElseThrow(() -> new SoolSoolException(LiquorCtrErrorCode.NOT_LIQUOR_CTR_FOUND))
+            .updateCtr(impression, click);
     }
 }

--- a/src/main/java/com/woowacamp/soolsool/core/liquor/service/LiquorCtrService.java
+++ b/src/main/java/com/woowacamp/soolsool/core/liquor/service/LiquorCtrService.java
@@ -31,8 +31,18 @@ public class LiquorCtrService {
         final LiquorCtrImpression impression,
         final LiquorCtrClick click
     ) {
+        // JPA -> find -> memory update -> dirty check
         liquorCtrRepository.findByLiquorId(liquorId)
             .orElseThrow(() -> new SoolSoolException(LiquorCtrErrorCode.NOT_LIQUOR_CTR_FOUND))
             .updateCtr(impression, click);
+
+        // update query -> commit
+//        liquorCtrRepository.updateCtr(liquorId, impression, click); // 없어도 업데이트 하고 있어도 업데이트 한다
+        // 없는데 새로 넣는 경우가 문제자잖아
+        // 없으면 없는놈을 업데이트해서 어짜피 새로 생길일이 없다.
+
+        // RedisLiquorCtr vs LiquorCtr -> RedisLiquorCtr win
+
+        // RedisLiquorCtr가 있으면 LiquorCtr과 RLC 모두 getCtr()을 가지고 있어야한다.
     }
 }

--- a/src/main/java/com/woowacamp/soolsool/core/liquor/service/LiquorCtrService.java
+++ b/src/main/java/com/woowacamp/soolsool/core/liquor/service/LiquorCtrService.java
@@ -1,8 +1,7 @@
 package com.woowacamp.soolsool.core.liquor.service;
 
 import com.woowacamp.soolsool.core.liquor.code.LiquorCtrErrorCode;
-import com.woowacamp.soolsool.core.liquor.domain.vo.LiquorCtrClick;
-import com.woowacamp.soolsool.core.liquor.domain.vo.LiquorCtrImpression;
+import com.woowacamp.soolsool.core.liquor.domain.LiquorCtr;
 import com.woowacamp.soolsool.core.liquor.repository.LiquorCtrRepository;
 import com.woowacamp.soolsool.core.liquor.repository.redisson.LiquorCtrRedisRepository;
 import com.woowacamp.soolsool.global.exception.SoolSoolException;
@@ -26,23 +25,9 @@ public class LiquorCtrService {
     }
 
     @Transactional
-    public void writeBackCtr(
-        final Long liquorId,
-        final LiquorCtrImpression impression,
-        final LiquorCtrClick click
-    ) {
-        // JPA -> find -> memory update -> dirty check
-        liquorCtrRepository.findByLiquorId(liquorId)
+    public void writeBackCtr(final LiquorCtr latestLiquorCtr) {
+        liquorCtrRepository.findByLiquorId(latestLiquorCtr.getLiquorId())
             .orElseThrow(() -> new SoolSoolException(LiquorCtrErrorCode.NOT_LIQUOR_CTR_FOUND))
-            .updateCtr(impression, click);
-
-        // update query -> commit
-//        liquorCtrRepository.updateCtr(liquorId, impression, click); // 없어도 업데이트 하고 있어도 업데이트 한다
-        // 없는데 새로 넣는 경우가 문제자잖아
-        // 없으면 없는놈을 업데이트해서 어짜피 새로 생길일이 없다.
-
-        // RedisLiquorCtr vs LiquorCtr -> RedisLiquorCtr win
-
-        // RedisLiquorCtr가 있으면 LiquorCtr과 RLC 모두 getCtr()을 가지고 있어야한다.
+            .overwrite(latestLiquorCtr);
     }
 }

--- a/src/main/java/com/woowacamp/soolsool/core/liquor/service/LiquorCtrService.java
+++ b/src/main/java/com/woowacamp/soolsool/core/liquor/service/LiquorCtrService.java
@@ -1,10 +1,8 @@
 package com.woowacamp.soolsool.core.liquor.service;
 
-import com.woowacamp.soolsool.core.liquor.code.LiquorCtrErrorCode;
 import com.woowacamp.soolsool.core.liquor.domain.LiquorCtr;
 import com.woowacamp.soolsool.core.liquor.repository.LiquorCtrRepository;
 import com.woowacamp.soolsool.core.liquor.repository.redisson.LiquorCtrRedisRepository;
-import com.woowacamp.soolsool.global.exception.SoolSoolException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -26,8 +24,10 @@ public class LiquorCtrService {
 
     @Transactional
     public void writeBackCtr(final LiquorCtr latestLiquorCtr) {
-        liquorCtrRepository.findByLiquorId(latestLiquorCtr.getLiquorId())
-            .orElseThrow(() -> new SoolSoolException(LiquorCtrErrorCode.NOT_LIQUOR_CTR_FOUND))
-            .overwrite(latestLiquorCtr);
+        liquorCtrRepository.updateLiquorCtr(
+            latestLiquorCtr.getImpression(),
+            latestLiquorCtr.getClick(),
+            latestLiquorCtr.getLiquorId()
+        );
     }
 }

--- a/src/main/java/com/woowacamp/soolsool/core/liquor/service/LiquorService.java
+++ b/src/main/java/com/woowacamp/soolsool/core/liquor/service/LiquorService.java
@@ -64,11 +64,7 @@ public class LiquorService {
         final Liquor liquor = liquorRepository
             .save(request.toEntity(liquorBrew, liquorRegion, liquorStatus));
 
-        liquorCtrRepository.save(
-            LiquorCtr.builder()
-                .liquorId(liquor.getId())
-                .build()
-        );
+        liquorCtrRepository.save(new LiquorCtr(liquor.getId()));
 
         return liquor.getId();
     }

--- a/src/main/java/com/woowacamp/soolsool/core/liquor/service/LiquorService.java
+++ b/src/main/java/com/woowacamp/soolsool/core/liquor/service/LiquorService.java
@@ -64,7 +64,11 @@ public class LiquorService {
         final Liquor liquor = liquorRepository
             .save(request.toEntity(liquorBrew, liquorRegion, liquorStatus));
 
-        liquorCtrRepository.save(new LiquorCtr(liquor.getId()));
+        liquorCtrRepository.save(
+            LiquorCtr.builder()
+                .liquorId(liquor.getId())
+                .build()
+        );
 
         return liquor.getId();
     }

--- a/src/main/java/com/woowacamp/soolsool/core/liquor/service/LiquorService.java
+++ b/src/main/java/com/woowacamp/soolsool/core/liquor/service/LiquorService.java
@@ -69,7 +69,7 @@ public class LiquorService {
         return liquor.getId();
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public LiquorDetailResponse liquorDetail(final Long liquorId) {
         final Liquor liquor = liquorRepository.findById(liquorId)
             .orElseThrow(() -> new SoolSoolException(NOT_LIQUOR_FOUND));

--- a/src/main/java/com/woowacamp/soolsool/global/common/BaseEntity.java
+++ b/src/main/java/com/woowacamp/soolsool/global/common/BaseEntity.java
@@ -21,5 +21,4 @@ public class BaseEntity {
     @LastModifiedDate
     @Column(name = "modified_at")
     private LocalDateTime modifiedAt;
-
 }

--- a/src/test/java/com/woowacamp/soolsool/core/liquor/domain/LiquorCtrTest.java
+++ b/src/test/java/com/woowacamp/soolsool/core/liquor/domain/LiquorCtrTest.java
@@ -3,6 +3,8 @@ package com.woowacamp.soolsool.core.liquor.domain;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
+import com.woowacamp.soolsool.core.liquor.domain.vo.LiquorCtrClick;
+import com.woowacamp.soolsool.core.liquor.domain.vo.LiquorCtrImpression;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -38,9 +40,7 @@ class LiquorCtrTest {
         LiquorCtr liquorCtr = LiquorCtr.builder()
             .liquorId(1L)
             .build();
-        liquorCtr.increaseImpressionOne();
-        liquorCtr.increaseImpressionOne();
-        liquorCtr.increaseClickOne();
+        liquorCtr.updateCtr(new LiquorCtrImpression(2L), new LiquorCtrClick(1L));
 
         /* when & then */
         assertThat(liquorCtr.getCtr()).isEqualTo(0.5);

--- a/src/test/java/com/woowacamp/soolsool/core/liquor/domain/LiquorCtrTest.java
+++ b/src/test/java/com/woowacamp/soolsool/core/liquor/domain/LiquorCtrTest.java
@@ -35,9 +35,7 @@ class LiquorCtrTest {
     @DisplayName("클릭률을 구한다")
     void getCtr() {
         /* given */
-        LiquorCtr liquorCtr = LiquorCtr.builder()
-            .liquorId(1L)
-            .build();
+        LiquorCtr liquorCtr = new LiquorCtr(1L);
         liquorCtr.overwrite(new LiquorCtr(1L, 2L, 1L));
 
         /* when & then */

--- a/src/test/java/com/woowacamp/soolsool/core/liquor/domain/LiquorCtrTest.java
+++ b/src/test/java/com/woowacamp/soolsool/core/liquor/domain/LiquorCtrTest.java
@@ -40,18 +40,4 @@ class LiquorCtrTest {
         /* when & then */
         assertThat(liquorCtr.getCtr()).isEqualTo(0.5);
     }
-
-    @Test
-    @DisplayName("기존의 노출수와 클릭수를 새로운 LiquorCtr 값으로 덮어쓴다")
-    void overwrite() {
-        /* given */
-        LiquorCtr liquorCtr = new LiquorCtr(1L, 0L, 0L);
-        LiquorCtr newLiquorCtr = new LiquorCtr(1L, 2L, 1L);
-
-        /* when */
-        liquorCtr.overwrite(newLiquorCtr);
-
-        /* when & then */
-        assertThat(liquorCtr.getCtr()).isEqualTo(0.5);
-    }
 }

--- a/src/test/java/com/woowacamp/soolsool/core/liquor/domain/LiquorCtrTest.java
+++ b/src/test/java/com/woowacamp/soolsool/core/liquor/domain/LiquorCtrTest.java
@@ -16,7 +16,7 @@ class LiquorCtrTest {
 
 
         /* when & then */
-        assertThatCode(() -> LiquorCtr.builder().liquorId(1L).build())
+        assertThatCode(() -> new LiquorCtr(1L))
             .doesNotThrowAnyException();
     }
 
@@ -38,7 +38,7 @@ class LiquorCtrTest {
         LiquorCtr liquorCtr = LiquorCtr.builder()
             .liquorId(1L)
             .build();
-        liquorCtr.overwrite(LiquorCtr.builder().liquorId(1L).impression(2L).click(1L).build());
+        liquorCtr.overwrite(new LiquorCtr(1L, 2L, 1L));
 
         /* when & then */
         assertThat(liquorCtr.getCtr()).isEqualTo(0.5);

--- a/src/test/java/com/woowacamp/soolsool/core/liquor/domain/LiquorCtrTest.java
+++ b/src/test/java/com/woowacamp/soolsool/core/liquor/domain/LiquorCtrTest.java
@@ -3,8 +3,6 @@ package com.woowacamp.soolsool.core.liquor.domain;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
-import com.woowacamp.soolsool.core.liquor.domain.vo.LiquorCtrClick;
-import com.woowacamp.soolsool.core.liquor.domain.vo.LiquorCtrImpression;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -40,7 +38,7 @@ class LiquorCtrTest {
         LiquorCtr liquorCtr = LiquorCtr.builder()
             .liquorId(1L)
             .build();
-        liquorCtr.updateCtr(new LiquorCtrImpression(2L), new LiquorCtrClick(1L));
+        liquorCtr.overwrite(LiquorCtr.builder().liquorId(1L).impression(2L).click(1L).build());
 
         /* when & then */
         assertThat(liquorCtr.getCtr()).isEqualTo(0.5);

--- a/src/test/java/com/woowacamp/soolsool/core/liquor/domain/LiquorCtrTest.java
+++ b/src/test/java/com/woowacamp/soolsool/core/liquor/domain/LiquorCtrTest.java
@@ -35,8 +35,21 @@ class LiquorCtrTest {
     @DisplayName("클릭률을 구한다")
     void getCtr() {
         /* given */
-        LiquorCtr liquorCtr = new LiquorCtr(1L);
-        liquorCtr.overwrite(new LiquorCtr(1L, 2L, 1L));
+        LiquorCtr liquorCtr = new LiquorCtr(1L, 2L, 1L);
+
+        /* when & then */
+        assertThat(liquorCtr.getCtr()).isEqualTo(0.5);
+    }
+
+    @Test
+    @DisplayName("기존의 노출수와 클릭수를 새로운 LiquorCtr 값으로 덮어쓴다")
+    void overwrite() {
+        /* given */
+        LiquorCtr liquorCtr = new LiquorCtr(1L, 0L, 0L);
+        LiquorCtr newLiquorCtr = new LiquorCtr(1L, 2L, 1L);
+
+        /* when */
+        liquorCtr.overwrite(newLiquorCtr);
 
         /* when & then */
         assertThat(liquorCtr.getCtr()).isEqualTo(0.5);

--- a/src/test/java/com/woowacamp/soolsool/core/liquor/repository/redisson/LiquorCtrRedisRepositoryTest.java
+++ b/src/test/java/com/woowacamp/soolsool/core/liquor/repository/redisson/LiquorCtrRedisRepositoryTest.java
@@ -8,6 +8,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.redisson.api.RedissonClient;
@@ -30,8 +31,9 @@ class LiquorCtrRedisRepositoryTest {
     @Autowired
     RedissonClient redissonClient;
 
+    @BeforeEach
     @AfterEach
-    void setOffLiquorCtr() {
+    void setRedisLiquorCtr() {
         redissonClient.getMapCache(LIQUOR_CTR_KEY).clear();
     }
 

--- a/src/test/java/com/woowacamp/soolsool/core/liquor/service/LiquorServiceIntegrationTest.java
+++ b/src/test/java/com/woowacamp/soolsool/core/liquor/service/LiquorServiceIntegrationTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-import com.woowacamp.soolsool.core.liquor.domain.Liquor;
+import com.woowacamp.soolsool.config.RedisTestConfig;
 import com.woowacamp.soolsool.core.liquor.dto.LiquorDetailResponse;
 import com.woowacamp.soolsool.core.liquor.dto.LiquorModifyRequest;
 import com.woowacamp.soolsool.core.liquor.dto.LiquorSaveRequest;
@@ -37,7 +37,7 @@ import org.springframework.test.context.jdbc.Sql;
 @Import({LiquorService.class, LiquorBrewCache.class, LiquorStatusCache.class,
     LiquorRegionCache.class, LiquorQueryDslRepository.class,
     QuerydslConfig.class,
-    RedissonConfig.class, ReceiptRedisRepository.class, LiquorCtrRedisRepository.class})
+    RedisTestConfig.class, ReceiptRedisRepository.class, LiquorCtrRedisRepository.class})
 @DisplayName("통합 테스트: LiquorService")
 class LiquorServiceIntegrationTest {
 

--- a/src/test/java/com/woowacamp/soolsool/core/liquor/service/LiquorServiceIntegrationTest.java
+++ b/src/test/java/com/woowacamp/soolsool/core/liquor/service/LiquorServiceIntegrationTest.java
@@ -19,6 +19,7 @@ import com.woowacamp.soolsool.global.config.QuerydslConfig;
 import com.woowacamp.soolsool.global.exception.SoolSoolException;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.redisson.api.RedissonClient;
@@ -47,8 +48,9 @@ class LiquorServiceIntegrationTest {
     @Autowired
     RedissonClient redissonClient;
 
+    @BeforeEach
     @AfterEach
-    void setOffRedis() {
+    void setRedisLiquorCtr() {
         redissonClient.getMapCache(LIQUOR_CTR_KEY).clear();
     }
 

--- a/src/test/java/com/woowacamp/soolsool/core/liquor/service/LiquorServiceIntegrationTest.java
+++ b/src/test/java/com/woowacamp/soolsool/core/liquor/service/LiquorServiceIntegrationTest.java
@@ -18,6 +18,7 @@ import com.woowacamp.soolsool.core.receipt.repository.redisson.ReceiptRedisRepos
 import com.woowacamp.soolsool.global.config.QuerydslConfig;
 import com.woowacamp.soolsool.global.exception.SoolSoolException;
 import java.time.LocalDateTime;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.redisson.api.RedissonClient;
@@ -45,6 +46,11 @@ class LiquorServiceIntegrationTest {
 
     @Autowired
     RedissonClient redissonClient;
+
+    @AfterEach
+    void setOffRedis() {
+        redissonClient.getMapCache(LIQUOR_CTR_KEY).clear();
+    }
 
     @Test
     @Sql({
@@ -79,8 +85,6 @@ class LiquorServiceIntegrationTest {
     @DisplayName("상품 상세정보를 조회할 경우 클릭율을 증가시킨다.")
     void increaseClick() {
         // given
-        redissonClient.getMapCache(LIQUOR_CTR_KEY).clear();
-
         long liquorId = 1L;
 
         // when
@@ -96,8 +100,6 @@ class LiquorServiceIntegrationTest {
     @DisplayName("상품 목록을 조회할 경우 클릭율을 증가시킨다.")
     void increaseImpression() {
         // given
-        redissonClient.getMapCache(LIQUOR_CTR_KEY).clear();
-
         long liquorId = 1L;
 
         // when


### PR DESCRIPTION
## ♻️ 변경 사항

LiquorCtr 반영 방식 리팩토링

<br>

## 📌 참고 사항

### MySQL, Redis에 저장되는 CTR 정보
* Redis, MySQL 모두 전체 클릭수와 노출수를 저장하고 있고, 차이점은 아래와 같음
Redis : 최신 CTR 정보가 반영됨
MySQL : Redis로부터 flush 된 정보가 반영됨

### CTR 증가 흐름
1. 상품 목록 또는 상세정보 조회 시 Redis에 저장된 노출수 or 클릭수(이하 CTR)를 증가시킨다.
2. 만약 Redis에 저장된 CTR 정보가 없다면 아래의 명령을 수행한다.
    1. MySQL에서 CTR 정보를 조회한다.
    2. 조회한 CTR 정보를 Redis에 저장하고, 5분 후 만료되도록 설정한다.
3. 5분이 지나 데이터가 만료되면, Redis에 갱신된 CTR 정보를 MySQL에 반영한다.

### ea48b27 변동 사항
1. RedisLiquorCtr에 toEntity 추가 (-> LiquorCtr)
2. 클릭율 조회 시 toEntity를 통해 LiquorCtr로 변환한 후 getCtr 로직 재사용 (중복 로직 삭제)

=> toEntity를 추가하여 getCtr 중복 로직을 삭제하고, Entity가 Redis, Event 등 이곳저곳을 돌아다니는 문제 방지

<br>

## 🎸 기타

```
ex) 닫을 이슈가 있다면,
closes #이슈번호
```
closes #218 
