### PR TITLE
refactor: 여러 개의 RLock을 MultiLock으로 관리

### DIFF
--- a/src/main/java/com/woowacamp/soolsool/core/liquor/repository/redisson/LiquorCtrRedisRepository.java
+++ b/src/main/java/com/woowacamp/soolsool/core/liquor/repository/redisson/LiquorCtrRedisRepository.java
@@ -20,7 +20,7 @@ import org.springframework.stereotype.Component;
 @Component
 @Slf4j
 public class LiquorCtrRedisRepository {
-
+    // TODO: ~Repository vs ~Service
     private static final String LIQUOR_CTR_KEY = "LIQUOR_CTR";
     private static final long LOCK_WAIT_TIME = 3L;
     private static final long LOCK_LEASE_TIME = 3L;
@@ -32,7 +32,6 @@ public class LiquorCtrRedisRepository {
 
     private final RMapCache<Long, RedisLiquorCtr> liquorCtrs;
 
-    // TODO: LiquorCtrRedisService vs LiquorCtrRedisRepository -> 취향 차이다...
     public LiquorCtrRedisRepository(
         final LiquorCtrRepository liquorCtrRepository,
         final RedissonClient redissonClient,
@@ -57,17 +56,6 @@ public class LiquorCtrRedisRepository {
         return lookUpLiquorCtr(liquorId).toEntity(liquorId).getCtr();
     }
 
-    // JpaRepository.updateAgeOne
-    // RedisRepository.updateImpressionOne
-
-    // 비관전락 했을 때 LiquorCtrRepsotiory.findById() <- @Lock
-    // Repository에서 락을 건게 아닌가?
-    // RLock을 Redis에서 빌린다고 생각 -> redissonClient.getLock() 자체가 Redis에 락 요청 보내는거아냐?
-
-    // AOP 구현했을 때 -> @Transactional -> repository에도 붙인다.
-    // Service 메서드에서 트랜잭션 시작을 원치 않을 수도 있다
-    // service.method( repo.m1, repo.m2 )
-    // repository에서 @RedisLock 을 붙이는게 자연스럽다...?
     public void increaseImpression(final Long liquorId) {
         final RLock liquorCtrLock = getLiquorCtrLock(liquorId);
 

--- a/src/main/java/com/woowacamp/soolsool/core/member/service/MemberService.java
+++ b/src/main/java/com/woowacamp/soolsool/core/member/service/MemberService.java
@@ -107,7 +107,7 @@ public class MemberService {
         final Long memberId,
         final MemberMileageChargeRequest memberMileageChargeRequest
     ) {
-        final RLock rLock = redissonClient.getLock(LockType.MEMBER.getPrefix() + memberId);
+        final RLock rLock = getMemberLock(memberId);
 
         try {
             rLock.tryLock(LOCK_WAIT_TIME, LOCK_LEASE_TIME, TimeUnit.SECONDS);
@@ -128,6 +128,10 @@ public class MemberService {
         } finally {
             unlock(rLock);
         }
+    }
+
+    private RLock getMemberLock(Long memberId) {
+        return redissonClient.getLock(LockType.MEMBER.getPrefix() + memberId);
     }
 
     private void unlock(final RLock rLock) {


### PR DESCRIPTION
## ♻️ 변경 사항

PayService, OrderService : 여러 개의 Lock을 개별적으로 점유, 해제하는 로직을 MultiLock으로 한 번에 관리하도록 수정
LiquorCtrRedisRepository : RMapCache를 로컬 변수에서 필드로 옮기고, 각 메서드에서 해당 필드를 사용하도록 수정
MemberService : Lock 점유하는 로직을 메서드로 분리

<br>

## 📌 참고 사항


<br>

## 🎸 기타

closes #225 
